### PR TITLE
[FEAT] Add basic routing setup to app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,15 +1,33 @@
+import { useCallback, useEffect, useState } from "react";
 import { useFonts } from "expo-font";
+import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { StyleSheet, Text, View } from "react-native";
 import { Button, WhiteSpace } from "@ant-design/react-native";
 
 import { StyledText } from "@components/StyledText";
 
+// Keep the splash screen visible fetching resources
+SplashScreen.preventAutoHideAsync();
+
 const App = () => {
   // Load fonts
   const [fontsLoaded] = useFonts({
     WorkSans: require("@assets/fonts/WorkSans.ttf"),
   });
+
+  // Memoized function to remove splash screen
+  const onRootLayoutView = useCallback(async () => {
+    if (fontsLoaded) {
+      await SplashScreen.hideAsync();
+    }
+  }, [fontsLoaded]);
+
+  // Call the onRootLayoutView function to remove splash screen
+  // This setup prevents it from being called multiple times
+  useEffect(() => {
+    onRootLayoutView();
+  }, [onRootLayoutView]);
 
   if (!fontsLoaded) {
     return null;

--- a/App.tsx
+++ b/App.tsx
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
-import { StatusBar } from "expo-status-bar";
-import { StyleSheet, Text, View } from "react-native";
-import { Button, WhiteSpace } from "@ant-design/react-native";
 
-import { StyledText } from "@components/StyledText";
+import { NavigationContainer } from "@react-navigation/native";
+
+import { TabNavigator } from "@navigators/TabNavigator";
 
 // Keep the splash screen visible fetching resources
 SplashScreen.preventAutoHideAsync();
@@ -34,30 +33,10 @@ const App = () => {
   }
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.huge}>Default Font Family Sample Text</Text>
-      <StyledText style={styles.huge}>
-        WorkSans Font Family Sample Text
-      </StyledText>
-      <WhiteSpace />
-      <Button type={"primary"}>
-        <StyledText>Sample Button Text</StyledText>
-      </Button>
-      <StatusBar style="auto" />
-    </View>
+    <NavigationContainer>
+      <TabNavigator />
+    </NavigationContainer>
   );
 };
-
-const styles = StyleSheet.create({
-  huge: {
-    fontSize: 20,
-  },
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-});
 
 export default App;

--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,9 @@ module.exports = function (api) {
         {
           alias: {
             "@components": "./src/components",
+            "@navigators": "./src/navigators",
+            "@screens": "./src/screens",
+            "@constants": "./src/constants",
             "@assets": "./assets",
           },
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2517,6 +2517,81 @@
       "resolved": "https://registry.npmjs.org/@react-native/polyfills/-/polyfills-2.0.0.tgz",
       "integrity": "sha512-K0aGNn1TjalKj+65D7ycc1//H9roAQ51GJVk5ZJQFb2teECGmzd86bYDC0aYdbRf7gtovescq4Zt6FR0tgXiHQ=="
     },
+    "@react-navigation/bottom-tabs": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@react-navigation/bottom-tabs/-/bottom-tabs-6.5.0.tgz",
+      "integrity": "sha512-7jKBHAk/HpIwXEsKKegB0DabPhFWS9PH2Bsmd4HUdvHj103m7H3OsrszuPB9Uxbe3RkGNtcJzeQnYOanVzNR+w==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.10",
+        "color": "^4.2.3",
+        "warn-once": "^0.1.0"
+      }
+    },
+    "@react-navigation/core": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-6.4.4.tgz",
+      "integrity": "sha512-skdTzr6sOceEusEDG+e58zaSpgy1Yz7eZGFtmkmdYAFkZDy5nkIY/0nYuXP0waUYarNXg6lNEVkF995/kZXHZg==",
+      "requires": {
+        "@react-navigation/routers": "^6.1.5",
+        "escape-string-regexp": "^4.0.0",
+        "nanoid": "^3.1.23",
+        "query-string": "^7.1.3",
+        "react-is": "^16.13.0",
+        "use-latest-callback": "^0.1.5"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "@react-navigation/elements": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@react-navigation/elements/-/elements-1.3.10.tgz",
+      "integrity": "sha512-JFaoZG9S+Zz291CvAMeGw8kNl/g2AaY9Pbo+VcYO+JM6UF/E5Obq9ga2ydxDrn3an7wzdl6flA/4lWhqG82Vqw=="
+    },
+    "@react-navigation/native": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.1.0.tgz",
+      "integrity": "sha512-CdjOmbE4c/UczczqeP7ZrFXJcjnXOCwY1PDNjX51Ph1b2tHXpQ41/089k3R49dc5i2sFLk6jKaryFU2dcLr8jw==",
+      "requires": {
+        "@react-navigation/core": "^6.4.4",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.1.23"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
+      }
+    },
+    "@react-navigation/native-stack": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-6.9.5.tgz",
+      "integrity": "sha512-1ZIrla+b4gB8KDC6QewtZ/1yOS23bQctwR4Pf6ECA0stEH8ibbxh70iiI/LluL5CtWxrWfgOrl1jpQsVvtKY+Q==",
+      "requires": {
+        "@react-navigation/elements": "^1.3.10",
+        "warn-once": "^0.1.0"
+      }
+    },
+    "@react-navigation/routers": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@react-navigation/routers/-/routers-6.1.5.tgz",
+      "integrity": "sha512-JzMRiRRu8J0yUMC7BV8wOVzevjkHnIPONbpCTL/vH5yceTm+dSH/U3esIObgk8wYYbov+jYlVhwUQNGRb2to6g==",
+      "requires": {
+        "nanoid": "^3.1.23"
+      }
+    },
     "@segment/loosely-validate-event": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -3456,6 +3531,30 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -4266,6 +4365,11 @@
         }
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -4338,6 +4442,11 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
+    },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="
     },
     "finalhandler": {
       "version": "1.1.2",
@@ -6139,6 +6248,11 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -6756,6 +6870,17 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "query-string": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "requires": {
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -6844,6 +6969,11 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.22.0"
       }
+    },
+    "react-freeze": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.3.tgz",
+      "integrity": "sha512-ZnXwLQnGzrDpHBHiC56TXFXvmolPeMjTn1UOm610M4EXGzbEDR7oOIyS2ZiItgbs6eZc4oU/a0hpk8PrcKvv5g=="
     },
     "react-is": {
       "version": "17.0.2",
@@ -7004,6 +7134,11 @@
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.70.3.tgz",
       "integrity": "sha512-oOanj84fJEXUg9FoEAQomA8ISG+DVIrTZ3qF7m69VQUJyOGYyDZmPqKcjvRku4KXlEH6hWO9i4ACLzNBh8gC0A=="
     },
+    "react-native-iphone-x-helper": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz",
+      "integrity": "sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg=="
+    },
     "react-native-modal-popover": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-native-modal-popover/-/react-native-modal-popover-2.1.0.tgz",
@@ -7012,6 +7147,25 @@
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       }
+    },
+    "react-native-safe-area-context": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.4.1.tgz",
+      "integrity": "sha512-N9XTjiuD73ZpVlejHrUWIFZc+6Z14co1K/p1IFMkImU7+avD69F3y+lhkqA2hN/+vljdZrBSiOwXPkuo43nFQA=="
+    },
+    "react-native-screens": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-3.18.2.tgz",
+      "integrity": "sha512-ANUEuvMUlsYJ1QKukEhzhfrvOUO9BVH9Nzg+6eWxpn3cfD/O83yPBOF8Mx6x5H/2+sMy+VS5x/chWOOo/U7QJw==",
+      "requires": {
+        "react-freeze": "^1.0.0",
+        "warn-once": "^0.1.0"
+      }
+    },
+    "react-native-tab-view": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-2.16.0.tgz",
+      "integrity": "sha512-ac2DmT7+l13wzIFqtbfXn4wwfgtPoKzWjjZyrK1t+T8sdemuUvD4zIt+UImg03fu3s3VD8Wh/fBrIdcqQyZJWg=="
     },
     "react-native-web": {
       "version": "0.18.10",
@@ -7025,6 +7179,17 @@
         "normalize-css-color": "^1.0.2",
         "postcss-value-parser": "^4.2.0",
         "styleq": "^0.1.2"
+      }
+    },
+    "react-navigation-tabs": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/react-navigation-tabs/-/react-navigation-tabs-2.11.2.tgz",
+      "integrity": "sha512-8w/fiX+gGIyxYWBUT6Fg/26DTggjzK4lPfnLTP1pR7DUfYGLf2/f/aJWqiIJt6U4k/19tzpr4sXQqG7fX6PLjg==",
+      "requires": {
+        "hoist-non-react-statics": "^3.3.2",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-native-iphone-x-helper": "^1.3.0",
+        "react-native-tab-view": "^2.15.2"
       }
     },
     "react-refresh": {
@@ -7709,6 +7874,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -7778,6 +7948,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg=="
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="
     },
     "string-width": {
       "version": "4.2.3",
@@ -8332,6 +8507,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
     },
+    "use-latest-callback": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.1.5.tgz",
+      "integrity": "sha512-HtHatS2U4/h32NlkhupDsPlrbiD27gSH5swBdtXbCAlc6pfOFzaj0FehW/FO12rx8j2Vy4/lJScCiJyM01E+bQ=="
+    },
     "use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -8387,6 +8567,11 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "warn-once": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
+      "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q=="
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1555,6 +1555,49 @@
       "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-47.0.0.tgz",
       "integrity": "sha512-r0pWfuhkv7KIcXMUiNACJmJKKwlTBGMw9VZHNdppS8/0Nve8HZMTkNRFQzTHW1uH3pBj8jEXpyw/2vSWDHex9g=="
     },
+    "@expo/configure-splash-screen": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@expo/configure-splash-screen/-/configure-splash-screen-0.6.0.tgz",
+      "integrity": "sha512-4DyPoNXJqx9bN4nEwF3HQreo//ECu7gDe1Xor3dnnzFm9P/VDxAKdbEhA0n+R6fgkNfT2onVHWijqvdpTS3Xew==",
+      "requires": {
+        "color-string": "^1.5.3",
+        "commander": "^5.1.0",
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.6",
+        "lodash": "^4.17.15",
+        "pngjs": "^5.0.0",
+        "xcode": "^3.0.0",
+        "xml-js": "^1.6.11"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "pngjs": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+          "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
+      }
+    },
     "@expo/dev-server": {
       "version": "0.1.123",
       "resolved": "https://registry.npmjs.org/@expo/dev-server/-/dev-server-0.1.123.tgz",
@@ -3426,6 +3469,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "colorette": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
@@ -4120,6 +4172,15 @@
       "requires": {
         "compare-versions": "^3.4.0",
         "invariant": "^2.2.4"
+      }
+    },
+    "expo-splash-screen": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-0.17.5.tgz",
+      "integrity": "sha512-ejSO78hwHXz8T9u8kh8t4r6CR4h70iBvA65gX8GK+dYxZl6/IANPbIb2VnUpND9vqfW+JnkDw+ZFst+gDnkpcQ==",
+      "requires": {
+        "@expo/configure-splash-screen": "^0.6.0",
+        "@expo/prebuild-config": "5.0.7"
       }
     },
     "expo-status-bar": {
@@ -7440,6 +7501,21 @@
         }
       }
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8435,6 +8511,14 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
           "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
         }
+      }
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
       }
     },
     "xml2js": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react-dom": "18.1.0",
     "react-native": "0.70.5",
     "react-native-gesture-handler": "^2.8.0",
-    "react-native-web": "~0.18.9"
+    "react-native-web": "~0.18.9",
+    "expo-splash-screen": "~0.17.5"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/package.json
+++ b/package.json
@@ -15,14 +15,20 @@
     "@react-native-community/segmented-control": "^2.2.2",
     "@react-native-community/slider": "4.2.4",
     "@react-native-picker/picker": "^2.4.8",
+    "@react-navigation/bottom-tabs": "^6.5.0",
+    "@react-navigation/native": "^6.1.0",
+    "@react-navigation/native-stack": "^6.9.5",
     "expo": "~47.0.8",
+    "expo-splash-screen": "~0.17.5",
     "expo-status-bar": "~1.4.2",
     "react": "18.1.0",
     "react-dom": "18.1.0",
     "react-native": "0.70.5",
     "react-native-gesture-handler": "^2.8.0",
+    "react-native-safe-area-context": "4.4.1",
+    "react-native-screens": "~3.18.0",
     "react-native-web": "~0.18.9",
-    "expo-splash-screen": "~0.17.5"
+    "react-navigation-tabs": "^2.11.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/src/constants/routes.tsx
+++ b/src/constants/routes.tsx
@@ -1,0 +1,22 @@
+/* Route names */
+export const SIGN_UP = "SignUp";
+export const REFERRAL = "Referral";
+export const TERMS_OF_SERVICE = "TermsOfService";
+export const ONBOARDING = "Onboarding";
+
+export const WAIT_TIMES = "WaitTimes";
+// This is required for the wait time stack navigator
+// This route corresponds to the home for the wait times tab
+export const WAIT_TIMES_HOME = "WaitTimesHome";
+export const LOCATION_DETAILS = "LocationDetails";
+
+export const MAP = "Map";
+export const REWARDS = "Rewards";
+
+export const PROFILE = "Profile";
+// This is required for the profile stack navigator
+// This route corresponds to the home for the profile tab
+export const PROFILE_HOME = "ProfileHome";
+export const SUGGEST_POI = "SuggestPOI";
+export const NOTIFICATIONS = "Notifications";
+export const THEME = "Theme";

--- a/src/navigators/ProfileStackNavigator.tsx
+++ b/src/navigators/ProfileStackNavigator.tsx
@@ -1,0 +1,38 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+
+import { POISuggestionScreen } from "@screens/POISuggestionScreen";
+import * as ROUTES from "@constants/routes";
+import { NotificationsScreen } from "@screens/NotificationScreen";
+import { ThemeScreen } from "@screens/ThemeScreen";
+import { ProfileScreen } from "@screens/ProfileScreen";
+
+// Stack component to use for navigation
+const Stack = createNativeStackNavigator();
+
+/**
+ * Handles navigation for the profile section of the app
+ */
+export const ProfileStackNavigator = () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      options={{ title: "Profile" }}
+      name={ROUTES.PROFILE_HOME}
+      component={ProfileScreen}
+    />
+    <Stack.Screen
+      options={{ title: "Suggest a new POI" }}
+      name={ROUTES.SUGGEST_POI}
+      component={POISuggestionScreen}
+    />
+    <Stack.Screen
+      options={{ title: "Notification Settings" }}
+      name={ROUTES.NOTIFICATIONS}
+      component={NotificationsScreen}
+    />
+    <Stack.Screen
+      options={{ title: "App Appearance" }}
+      name={ROUTES.THEME}
+      component={ThemeScreen}
+    />
+  </Stack.Navigator>
+);

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -1,0 +1,38 @@
+import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
+
+import { RewardsScreen } from "@screens/RewardsScreen";
+import { MapScreen } from "@screens/MapScreen";
+import * as ROUTES from "@constants/routes";
+import { ProfileStackNavigator } from "@navigators/ProfileStackNavigator";
+import { WaitTimesNavigator } from "@navigators/WaitTimeStackNavigator";
+
+// Tab component to use for navigation
+const Tab = createBottomTabNavigator();
+
+/**
+ * Handles tab navigation for the main section of the app
+ */
+export const TabNavigator = () => (
+  <Tab.Navigator>
+    <Tab.Screen
+      name={ROUTES.WAIT_TIMES}
+      component={WaitTimesNavigator}
+      options={{ headerShown: false }}
+    />
+    <Tab.Screen
+      options={{ headerShown: false }}
+      name={ROUTES.MAP}
+      component={MapScreen}
+    />
+    <Tab.Screen
+      options={{ title: "Rewards" }}
+      name={ROUTES.REWARDS}
+      component={RewardsScreen}
+    />
+    <Tab.Screen
+      name={ROUTES.PROFILE}
+      component={ProfileStackNavigator}
+      options={{ headerShown: false }}
+    />
+  </Tab.Navigator>
+);

--- a/src/navigators/WaitTimeStackNavigator.tsx
+++ b/src/navigators/WaitTimeStackNavigator.tsx
@@ -1,0 +1,34 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+
+import { WaitTimeScreen } from "@screens/WaitTimeScreen";
+import { LocationDetailsScreen } from "@screens/LocationDetailsScreen";
+import * as ROUTES from "@constants/routes";
+
+// Types of parameters that are passed for each screen
+type IProfileStackNavigatorParams = {
+  [ROUTES.WAIT_TIMES_HOME]: undefined;
+  [ROUTES.LOCATION_DETAILS]: { location: string };
+};
+
+// Stack component to use for navigation
+const Stack = createNativeStackNavigator<IProfileStackNavigatorParams>();
+
+/**
+ * Handles navigation for the wait times section of the app
+ */
+export const WaitTimesNavigator = () => (
+  <Stack.Navigator initialRouteName={ROUTES.WAIT_TIMES_HOME}>
+    <Stack.Screen
+      options={{ headerShown: false }}
+      name={ROUTES.WAIT_TIMES_HOME}
+      component={WaitTimeScreen}
+    />
+    <Stack.Screen
+      options={({ route }) => ({
+        title: route.params.location,
+      })}
+      name={ROUTES.LOCATION_DETAILS}
+      component={LocationDetailsScreen}
+    />
+  </Stack.Navigator>
+);

--- a/src/screens/LocationDetailsScreen.tsx
+++ b/src/screens/LocationDetailsScreen.tsx
@@ -1,0 +1,19 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export const LocationDetailsScreen = ({ navigate }: any) => (
+  <View style={styles.container}>
+    <Text style={styles.huge}>Location Details Screen</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  huge: {
+    fontSize: 20,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,0 +1,19 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export const MapScreen = ({ navigate }: any) => (
+  <View style={styles.container}>
+    <Text style={styles.huge}>Map Screen</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  huge: {
+    fontSize: 20,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/screens/NotificationScreen.tsx
+++ b/src/screens/NotificationScreen.tsx
@@ -1,0 +1,19 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export const NotificationsScreen = ({ navigate }: any) => (
+  <View style={styles.container}>
+    <Text style={styles.huge}>Notifications Screen</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  huge: {
+    fontSize: 20,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/screens/POISuggestionScreen.tsx
+++ b/src/screens/POISuggestionScreen.tsx
@@ -1,0 +1,19 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export const POISuggestionScreen = ({ navigate }: any) => (
+  <View style={styles.container}>
+    <Text style={styles.huge}>POI Suggestion Screen</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  huge: {
+    fontSize: 20,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,0 +1,40 @@
+import { StyleSheet, View } from "react-native";
+
+import { Button, WhiteSpace } from "@ant-design/react-native";
+
+import { StyledText } from "@components/StyledText";
+import * as ROUTES from "@constants/routes";
+
+export const ProfileScreen = ({ navigation }: any) => (
+  <View style={styles.container}>
+    <StyledText style={styles.huge}>Profile Page</StyledText>
+    <WhiteSpace />
+    <Button
+      type={"primary"}
+      onPress={() => navigation.navigate(ROUTES.SUGGEST_POI)}
+    >
+      <StyledText>Go to POI Suggestion</StyledText>
+    </Button>
+    <Button
+      type={"primary"}
+      onPress={() => navigation.navigate(ROUTES.NOTIFICATIONS)}
+    >
+      <StyledText>Go to notifications</StyledText>
+    </Button>
+    <Button type={"primary"} onPress={() => navigation.navigate(ROUTES.THEME)}>
+      <StyledText>Go to appearance settings</StyledText>
+    </Button>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  huge: {
+    fontSize: 20,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/screens/RewardsScreen.tsx
+++ b/src/screens/RewardsScreen.tsx
@@ -1,0 +1,19 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export const RewardsScreen = ({ navigate }: any) => (
+  <View style={styles.container}>
+    <Text style={styles.huge}>Rewards Screen</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  huge: {
+    fontSize: 20,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/screens/ThemeScreen.tsx
+++ b/src/screens/ThemeScreen.tsx
@@ -1,0 +1,19 @@
+import { Text, View, StyleSheet } from "react-native";
+
+export const ThemeScreen = ({ navigate }: any) => (
+  <View style={styles.container}>
+    <Text style={styles.huge}>App Appearance Screen</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  huge: {
+    fontSize: 20,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/src/screens/WaitTimeScreen.tsx
+++ b/src/screens/WaitTimeScreen.tsx
@@ -1,0 +1,37 @@
+import { StatusBar } from "expo-status-bar";
+import { StyleSheet, Text, View } from "react-native";
+
+import { Button, WhiteSpace } from "@ant-design/react-native";
+
+import { StyledText } from "@components/StyledText";
+import { LOCATION_DETAILS } from "@constants/routes";
+
+export const WaitTimeScreen = ({ navigation }: any) => {
+  return (
+    <View style={styles.container}>
+      <StyledText style={styles.huge}>Wait Times</StyledText>
+      <WhiteSpace />
+      <Button
+        type={"primary"}
+        onPress={() =>
+          navigation.navigate(LOCATION_DETAILS, { location: "Location X" })
+        }
+      >
+        <StyledText>Go to Location X</StyledText>
+      </Button>
+      <StatusBar style="auto" />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  huge: {
+    fontSize: 20,
+  },
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
     "baseUrl": ".",
     "paths": {
       "@components/*": ["src/components/*"],
+      "@navigators/*": ["src/navigators/*"],
+      "@screens/*": ["src/screens/*"],
+      "@constants/*": ["src/constants/*"],
       "@assets/*": ["assets/*"]
     }
   },


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Adds the basic routing setup and sample screens to work with. Setup based on the authenticated screens present in the app. Will add more routing when we need to implement the authentication flow.
* It looks like a lot but most of the screens are just placeholders.

Closes #3 

This change is a

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [ ] Documentation update

## Preview
![Animation](https://user-images.githubusercontent.com/40010849/206884580-f5d06976-f4bb-4ea3-9e8e-563c29c97288.gif)

## Description
* Fix splash screen so that it stays put until all the font is loaded.
* Created routing constants that have the names of each page.
* Created 3 navigators
  * Tab navigator handles the tab navigation at the bottom of the screen
  * Profile Stack navigator is a stack-based navigator for handling navigation in the profile portion of the app
  * Wait time Stack navigator is a stack-based navigator for handling navigation in the wait time portion of the app.
* Each navigator is hooked up to a few screens and should kind of show the flow that's in the Figma.
* There's a whole bunch of screen files but they are all copy paste really simple sample screens to be updated later.

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->



## Motivation/Links
This lets the user move between screens freely.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->

## TODOs
* I'll hook up testing next I promise.
* I'll add type checking to the navigation stuff as soon as I can figure it out.
* We can customize the top bar, bottom nav, icons, etc. once we start working on the pages.