### PR TITLE
[FIX] Typescript prop types for react navigation

### DIFF
--- a/src/navigators/ProfileStackNavigator.tsx
+++ b/src/navigators/ProfileStackNavigator.tsx
@@ -1,4 +1,5 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 import { POISuggestionScreen } from "@screens/POISuggestionScreen";
 import * as ROUTES from "@constants/routes";
@@ -6,8 +7,40 @@ import { NotificationsScreen } from "@screens/NotificationScreen";
 import { ThemeScreen } from "@screens/ThemeScreen";
 import { ProfileScreen } from "@screens/ProfileScreen";
 
+// Types of parameters that are passed for each screen
+type ProfileStackNavigatorParams = {
+  [ROUTES.PROFILE_HOME]: undefined;
+  [ROUTES.SUGGEST_POI]: undefined;
+  [ROUTES.NOTIFICATIONS]: undefined;
+  [ROUTES.THEME]: undefined;
+};
+
+// Prop types for each of the screen in the navigator
+// ... ({ navigator, route }: RouteNameScreenProps)
+// OR navigator: RouteNameScreenProps['navigator']
+//    route: RouteNameScreenProps['route']
+export type ProfileScreenProps = NativeStackScreenProps<
+  ProfileStackNavigatorParams,
+  typeof ROUTES.PROFILE_HOME
+>;
+
+export type POISuggestionScreenProps = NativeStackScreenProps<
+  ProfileStackNavigatorParams,
+  typeof ROUTES.SUGGEST_POI
+>;
+
+export type NotificationScreenProps = NativeStackScreenProps<
+  ProfileStackNavigatorParams,
+  typeof ROUTES.NOTIFICATIONS
+>;
+
+export type ThemeScreenProps = NativeStackScreenProps<
+  ProfileStackNavigatorParams,
+  typeof ROUTES.THEME
+>;
+
 // Stack component to use for navigation
-const Stack = createNativeStackNavigator();
+const Stack = createNativeStackNavigator<ProfileStackNavigatorParams>();
 
 /**
  * Handles navigation for the profile section of the app

--- a/src/navigators/ProfileStackNavigator.tsx
+++ b/src/navigators/ProfileStackNavigator.tsx
@@ -16,8 +16,8 @@ type ProfileStackNavigatorParams = {
 };
 
 // Prop types for each of the screen in the navigator
-// ... ({ navigator, route }: RouteNameScreenProps)
-// OR navigator: RouteNameScreenProps['navigator']
+// ... ({ navigation, route }: RouteNameScreenProps)
+// OR navigator: RouteNameScreenProps['navigation']
 //    route: RouteNameScreenProps['route']
 export type ProfileScreenProps = NativeStackScreenProps<
   ProfileStackNavigatorParams,

--- a/src/navigators/WaitTimeStackNavigator.tsx
+++ b/src/navigators/WaitTimeStackNavigator.tsx
@@ -1,17 +1,32 @@
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 
 import { WaitTimeScreen } from "@screens/WaitTimeScreen";
 import { LocationDetailsScreen } from "@screens/LocationDetailsScreen";
 import * as ROUTES from "@constants/routes";
 
 // Types of parameters that are passed for each screen
-type IProfileStackNavigatorParams = {
+type WaitTimeStackNavigatorParams = {
   [ROUTES.WAIT_TIMES_HOME]: undefined;
   [ROUTES.LOCATION_DETAILS]: { location: string };
 };
 
+// Prop types for each of the screen in the navigator
+// ... ({ navigator, route }: RouteNameScreenProps)
+// OR navigator: RouteNameScreenProps['navigator']
+//    route: RouteNameScreenProps['route']
+export type WaitTimeScreenProps = NativeStackScreenProps<
+  WaitTimeStackNavigatorParams,
+  typeof ROUTES.WAIT_TIMES_HOME
+>;
+
+export type LocationDetailsScreenProps = NativeStackScreenProps<
+  WaitTimeStackNavigatorParams,
+  typeof ROUTES.LOCATION_DETAILS
+>;
+
 // Stack component to use for navigation
-const Stack = createNativeStackNavigator<IProfileStackNavigatorParams>();
+const Stack = createNativeStackNavigator<WaitTimeStackNavigatorParams>();
 
 /**
  * Handles navigation for the wait times section of the app

--- a/src/navigators/WaitTimeStackNavigator.tsx
+++ b/src/navigators/WaitTimeStackNavigator.tsx
@@ -12,8 +12,8 @@ type WaitTimeStackNavigatorParams = {
 };
 
 // Prop types for each of the screen in the navigator
-// ... ({ navigator, route }: RouteNameScreenProps)
-// OR navigator: RouteNameScreenProps['navigator']
+// ... ({ navigation, route }: RouteNameScreenProps)
+// OR navigator: RouteNameScreenProps['navigation']
 //    route: RouteNameScreenProps['route']
 export type WaitTimeScreenProps = NativeStackScreenProps<
   WaitTimeStackNavigatorParams,

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -4,8 +4,9 @@ import { Button, WhiteSpace } from "@ant-design/react-native";
 
 import { StyledText } from "@components/StyledText";
 import * as ROUTES from "@constants/routes";
+import { ProfileScreenProps } from "@navigators/ProfileStackNavigator";
 
-export const ProfileScreen = ({ navigation }: any) => (
+export const ProfileScreen = ({ navigation }: IProfileScreenProps) => (
   <View style={styles.container}>
     <StyledText style={styles.huge}>Profile Page</StyledText>
     <WhiteSpace />
@@ -38,3 +39,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
 });
+
+interface IProfileScreenProps {
+  navigation: ProfileScreenProps["navigation"];
+}

--- a/src/screens/WaitTimeScreen.tsx
+++ b/src/screens/WaitTimeScreen.tsx
@@ -5,8 +5,9 @@ import { Button, WhiteSpace } from "@ant-design/react-native";
 
 import { StyledText } from "@components/StyledText";
 import { LOCATION_DETAILS } from "@constants/routes";
+import { LocationDetailsScreenProps } from "@navigators/WaitTimeStackNavigator";
 
-export const WaitTimeScreen = ({ navigation }: any) => {
+export const WaitTimeScreen = ({ navigation }: IWaitTimeScreenProps) => {
   return (
     <View style={styles.container}>
       <StyledText style={styles.huge}>Wait Times</StyledText>
@@ -35,3 +36,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
 });
+
+interface IWaitTimeScreenProps {
+  navigation: LocationDetailsScreenProps["navigation"];
+}


### PR DESCRIPTION
## Overview

Adds prop types for the different routes that navigators will use. This lets us properly type the arguments (`navigation` and `route`)  supplied from react-navigation in typescript without it being scuffed.

Basically followed this: https://reactnavigation.org/docs/typescript/#annotating-usenavigation

Closes #22 

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change exisiting functionality)
- [ ] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->
* Add some new types according to docs. Extends some types. Type wizard shit. I've come to understand I understand very little about generic typing.
* Fix typing on screen components. Makes it easier to work with in the future.
* Left some comments on how to type things.

## Motivation/Links
Doing things properly. Typescript is sometimes a pain. But also kind of nice somethings. Just not today.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
