### PR TITLE
[FEAT] Build UI-4.4 page for changing the theme

### DIFF
--- a/src/components/StyledText.tsx
+++ b/src/components/StyledText.tsx
@@ -1,5 +1,7 @@
-import React from "react";
+import { useContext } from "react";
 import { StyleSheet, Text } from "react-native";
+
+import { ThemeContext } from "@contexts/theme";
 
 /**
  * Text wrapper component with global text style applied
@@ -10,6 +12,7 @@ export const StyledText = ({
   fontWeight = "normal",
   ...otherProps
 }: Partial<IStyledTextProps>) => {
+  const { theme } = useContext(ThemeContext);
   const styles = StyleSheet.create({
     text: {
       fontFamily: fontWeight === "bold" ? "WorkSansBold" : "WorkSans",
@@ -17,7 +20,7 @@ export const StyledText = ({
   });
 
   return (
-    <Text {...otherProps} style={[styles.text, style]}>
+    <Text {...otherProps} style={[theme.styles.text, styles.text, style]}>
       {children}
     </Text>
   );

--- a/src/constants/theme.tsx
+++ b/src/constants/theme.tsx
@@ -1,14 +1,16 @@
 import { StyleSheet } from "react-native";
 import { PRIMARY_COLOR_LIGHT } from "./styles";
 
-export const LIGHT = "light";
-export const DARK = "dark";
-export const SYSTEM = "system";
+export const THEME_NAMES = {
+  light: "light",
+  dark: "dark",
+  system: "system",
+};
 
 export const themes = {
   // Light theme
   light: {
-    name: LIGHT, // Name of theme
+    name: THEME_NAMES.light, // Name of theme
     styles: StyleSheet.create({
       screenContainer: {
         flex: 1,
@@ -32,7 +34,7 @@ export const themes = {
   },
   // Dark theme
   dark: {
-    name: DARK,
+    name: THEME_NAMES.dark,
     styles: StyleSheet.create({
       screenContainer: {
         flex: 1,

--- a/src/constants/theme.tsx
+++ b/src/constants/theme.tsx
@@ -20,6 +20,7 @@ export const themes = {
       },
       text: {
         color: "#000000",
+        fontSize: 15,
       },
       primaryColor: {
         color: PRIMARY_COLOR_LIGHT,
@@ -44,6 +45,7 @@ export const themes = {
       },
       text: {
         color: "#ffffff",
+        fontSize: 15,
       },
       primaryColor: {
         color: PRIMARY_COLOR_LIGHT,

--- a/src/constants/theme.tsx
+++ b/src/constants/theme.tsx
@@ -6,8 +6,14 @@ export const themes = {
   light: {
     name: "light", // Name of theme
     styles: StyleSheet.create({
-      container: {
+      screenContainer: {
+        flex: 1,
+        padding: 15,
+        paddingTop: 20,
         backgroundColor: "#ffffff",
+      },
+      text: {
+        color: "#000000",
       },
       primaryColor: {
         color: PRIMARY_COLOR_LIGHT,
@@ -18,15 +24,20 @@ export const themes = {
         Add any values from the ant default theme you want to override here
         https://github.com/ant-design/ant-design-mobile-rn/blob/master/components/style/themes/default.tsx
       */
-      // primary_button_fill: "#34cb38",
     },
   },
   // Dark theme
   dark: {
     name: "dark",
     styles: StyleSheet.create({
-      container: {
+      screenContainer: {
+        flex: 1,
+        padding: 15,
+        paddingTop: 20,
         backgroundColor: "#222222",
+      },
+      text: {
+        color: "#ffffff",
       },
       primaryColor: {
         color: PRIMARY_COLOR_LIGHT,
@@ -38,6 +49,9 @@ export const themes = {
         https://github.com/ant-design/ant-design-mobile-rn/blob/master/components/style/themes/default.tsx
       */
       primary_button_fill: "#a00ceb",
+      checkbox_fill: "#bf40bf", // Radio/checkbox button color
+      fill_base: "#222222", // Background color
+      border_color_base: "#fffff", // Line color
     },
   },
 };

--- a/src/constants/theme.tsx
+++ b/src/constants/theme.tsx
@@ -1,10 +1,14 @@
 import { StyleSheet } from "react-native";
 import { PRIMARY_COLOR_LIGHT } from "./styles";
 
+export const LIGHT = "light";
+export const DARK = "dark";
+export const SYSTEM = "system";
+
 export const themes = {
   // Light theme
   light: {
-    name: "light", // Name of theme
+    name: LIGHT, // Name of theme
     styles: StyleSheet.create({
       screenContainer: {
         flex: 1,
@@ -28,7 +32,7 @@ export const themes = {
   },
   // Dark theme
   dark: {
-    name: "dark",
+    name: DARK,
     styles: StyleSheet.create({
       screenContainer: {
         flex: 1,

--- a/src/contexts/__tests__/theme.test.tsx
+++ b/src/contexts/__tests__/theme.test.tsx
@@ -4,7 +4,8 @@ import { View, Text } from "react-native";
 import { render, screen, fireEvent } from "@testing-library/react-native";
 import { Button } from "@ant-design/react-native";
 
-import { ThemeProvider, ThemeContext } from "@contexts/theme";
+import { ThemeContext } from "@contexts/theme";
+import { renderWithTheme } from "@contexts/utils/theme.utils";
 
 import "@testing-library/jest-native/extend-expect";
 
@@ -37,23 +38,6 @@ describe("<ThemeProvider />", () => {
   const DARK = "dark";
   const SYSTEM = "system";
 
-  /**
-   * A custom render to setup providers. Extends regular
-   * render options with `providerProps` to allow injecting
-   * different scenarios to test with.
-   *
-   * @see https://testing-library.com/docs/react-testing-library/setup#custom-render
-   */
-  const customRender = (
-    children: React.ReactNode,
-    { providerProps, ...renderOptions }: any = {}
-  ) => {
-    return render(
-      <ThemeProvider {...providerProps}>{children}</ThemeProvider>,
-      renderOptions
-    );
-  };
-
   it("renders the default theme and choice when missing a provider", () => {
     render(<SampleThemeConsumer />);
     expect(getThemeName()).toHaveTextContent(`Current theme:${LIGHT}`);
@@ -61,9 +45,7 @@ describe("<ThemeProvider />", () => {
   });
 
   it("renders the correct theme passed", () => {
-    customRender(<SampleThemeConsumer />, {
-      providerProps: { startThemePreference: DARK },
-    });
+    renderWithTheme(<SampleThemeConsumer />, DARK);
     expect(getThemeName()).toHaveTextContent(`Current theme:${DARK}`);
     expect(getThemePref()).toHaveTextContent(`Current theme choice:${DARK}`);
     expect(getButton()).toHaveStyle({
@@ -72,9 +54,7 @@ describe("<ThemeProvider />", () => {
   });
 
   it("correctly updates the theme and re-renders components", async () => {
-    customRender(<SampleThemeConsumer />, {
-      providerProps: { startThemePreference: LIGHT },
-    });
+    renderWithTheme(<SampleThemeConsumer />, LIGHT);
     expect(getThemeName()).toHaveTextContent(`Current theme:${LIGHT}`);
     expect(getButton()).toHaveStyle({
       backgroundColor: "#108ee9",

--- a/src/contexts/__tests__/theme.test.tsx
+++ b/src/contexts/__tests__/theme.test.tsx
@@ -15,7 +15,8 @@ const buttonTestId = "ant-button";
 const getThemeName = () => screen.getByText(/^Current theme:/);
 const getThemePref = () => screen.getByText(/^Current theme choice:/);
 const getButton = () => screen.getByTestId(buttonTestId);
-const flipTheme = (current: string) => (current === "light" ? "dark" : "light");
+const flipTheme = (current: string) =>
+  current === THEME_NAMES.light ? THEME_NAMES.dark : THEME_NAMES.dark;
 
 const SampleThemeConsumer = () => {
   const { theme, themePreference, changeTheme } = useContext(ThemeContext);
@@ -54,7 +55,7 @@ describe("<ThemeProvider />", () => {
     });
   });
 
-  it("correctly updates the theme and re-renders components", async () => {
+  it("correctly updates the theme and re-renders components", () => {
     renderWithTheme(<SampleThemeConsumer />, LIGHT);
     expect(getThemeName()).toHaveTextContent(`Current theme:${LIGHT}`);
     expect(getButton()).toHaveStyle({

--- a/src/contexts/__tests__/theme.test.tsx
+++ b/src/contexts/__tests__/theme.test.tsx
@@ -6,6 +6,7 @@ import { Button } from "@ant-design/react-native";
 
 import { ThemeContext } from "@contexts/theme";
 import { renderWithTheme } from "@contexts/utils/theme.utils";
+import { THEME_NAMES } from "@constants/theme";
 
 import "@testing-library/jest-native/extend-expect";
 
@@ -34,9 +35,9 @@ const SampleThemeConsumer = () => {
 };
 
 describe("<ThemeProvider />", () => {
-  const LIGHT = "light";
-  const DARK = "dark";
-  const SYSTEM = "system";
+  const LIGHT = THEME_NAMES.light;
+  const DARK = THEME_NAMES.dark;
+  const SYSTEM = THEME_NAMES.system;
 
   it("renders the default theme and choice when missing a provider", () => {
     render(<SampleThemeConsumer />);

--- a/src/contexts/theme.tsx
+++ b/src/contexts/theme.tsx
@@ -4,13 +4,16 @@ import * as SecureStore from "expo-secure-store";
 
 import { Provider } from "@ant-design/react-native";
 
-import { themes, STORAGE_KEY } from "@constants/theme";
+import { themes, STORAGE_KEY, THEME_NAMES } from "@constants/theme";
 
 // Theme Defaults
-export const DEFAULT_CHOICE = "system";
+export const DEFAULT_CHOICE = THEME_NAMES.system;
 export const DEFAULT_THEME = themes.light;
 
-export type ThemeChoice = "system" | "light" | "dark";
+export type ThemeChoice =
+  | typeof THEME_NAMES.system
+  | typeof THEME_NAMES.light
+  | typeof THEME_NAMES.dark;
 
 export const ThemeContext = React.createContext({
   theme: DEFAULT_THEME,
@@ -80,13 +83,15 @@ export const ThemeProvider = ({
   // is changed or the system color theme changes
   useEffect(() => {
     if (
-      themePreference === "light" ||
-      (themePreference === "system" && colorScheme === "light")
+      themePreference === THEME_NAMES.light ||
+      (themePreference === THEME_NAMES.system &&
+        colorScheme === THEME_NAMES.light)
     ) {
       setTheme(themes.light);
     } else if (
-      themePreference === "dark" ||
-      (themePreference === "system" && colorScheme === "dark")
+      themePreference === THEME_NAMES.dark ||
+      (themePreference === THEME_NAMES.system &&
+        colorScheme === THEME_NAMES.dark)
     ) {
       setTheme(themes.dark);
     } else {

--- a/src/contexts/utils/theme.utils.tsx
+++ b/src/contexts/utils/theme.utils.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from "@testing-library/react-native";
+
+import { ThemeProvider, DEFAULT_CHOICE, ThemeChoice } from "@contexts/theme";
+
+/**
+ * Theme Testing Utils
+ */
+
+/**
+ * A custom render to setup providers. Extends regular
+ * render options with `providerProps` to allow injecting
+ * different scenarios to test with.
+ *
+ * @see https://testing-library.com/docs/react-testing-library/setup#custom-render
+ */
+export const renderWithTheme = (
+  children: React.ReactNode,
+  startThemePreference: ThemeChoice = DEFAULT_CHOICE,
+  renderOptions = {}
+) => {
+  return render(
+    <ThemeProvider startThemePreference={startThemePreference}>
+      {children}
+    </ThemeProvider>,
+    renderOptions
+  );
+};

--- a/src/contexts/utils/theme.utils.tsx
+++ b/src/contexts/utils/theme.utils.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react-native";
+import { render } from "@testing-library/react-native";
 
 import { ThemeProvider, DEFAULT_CHOICE, ThemeChoice } from "@contexts/theme";
 
@@ -7,9 +7,8 @@ import { ThemeProvider, DEFAULT_CHOICE, ThemeChoice } from "@contexts/theme";
  */
 
 /**
- * A custom render to setup providers. Extends regular
- * render options with `providerProps` to allow injecting
- * different scenarios to test with.
+ * A custom render to use theme provider to wrap normal components to test theming.
+ * Extends regular render options and can pass the theme preference to render.
  *
  * @see https://testing-library.com/docs/react-testing-library/setup#custom-render
  */

--- a/src/screens/ThemeScreen.tsx
+++ b/src/screens/ThemeScreen.tsx
@@ -20,17 +20,17 @@ export const ThemeScreen = () => {
         onChange={(e: any) => changeTheme(e.target.value)}
         value={themePreference}
       >
-        <Radio.RadioItem value={"system"} left>
+        <Radio.RadioItem style={styles.radio} value={"system"} left>
           <View style={styles.option}>
             <StyledText style={styles.optionText}>System</StyledText>
           </View>
         </Radio.RadioItem>
-        <Radio.RadioItem value={"light"} left>
+        <Radio.RadioItem style={styles.radio} value={"light"} left>
           <View style={styles.option}>
             <StyledText style={styles.optionText}>Light</StyledText>
           </View>
         </Radio.RadioItem>
-        <Radio.RadioItem value={"dark"} left>
+        <Radio.RadioItem style={styles.radio} value={"dark"} left>
           <View style={styles.option}>
             <StyledText style={styles.optionText}>Dark</StyledText>
           </View>
@@ -41,6 +41,9 @@ export const ThemeScreen = () => {
 };
 
 const styles = StyleSheet.create({
+  radio: {
+    paddingVertical: 5,
+  },
   option: {
     flex: 1,
     flexDirection: "column",

--- a/src/screens/ThemeScreen.tsx
+++ b/src/screens/ThemeScreen.tsx
@@ -22,17 +22,17 @@ export const ThemeScreen = () => {
       >
         <Radio.RadioItem value={"system"} left>
           <View style={styles.option}>
-            <StyledText>System</StyledText>
+            <StyledText style={styles.optionText}>System</StyledText>
           </View>
         </Radio.RadioItem>
         <Radio.RadioItem value={"light"} left>
           <View style={styles.option}>
-            <StyledText>Light</StyledText>
+            <StyledText style={styles.optionText}>Light</StyledText>
           </View>
         </Radio.RadioItem>
         <Radio.RadioItem value={"dark"} left>
           <View style={styles.option}>
-            <StyledText>Dark</StyledText>
+            <StyledText style={styles.optionText}>Dark</StyledText>
           </View>
         </Radio.RadioItem>
       </Radio.Group>
@@ -46,5 +46,8 @@ const styles = StyleSheet.create({
     flexDirection: "column",
     justifyContent: "center",
     marginLeft: -4,
+  },
+  optionText: {
+    fontSize: 16,
   },
 });

--- a/src/screens/ThemeScreen.tsx
+++ b/src/screens/ThemeScreen.tsx
@@ -1,40 +1,50 @@
 import { useContext } from "react";
-import { Text, View, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
 
-import { Button, WhiteSpace } from "@ant-design/react-native";
+import { WhiteSpace, View, Radio } from "@ant-design/react-native";
 
 import { ThemeContext } from "@contexts/theme";
+import { StyledText } from "@components/StyledText";
 
 export const ThemeScreen = () => {
-  const { theme, changeTheme } = useContext(ThemeContext);
-
-  const styles = StyleSheet.create({
-    huge: {
-      fontSize: 20,
-    },
-    container: {
-      flex: 1,
-      alignItems: "center",
-      justifyContent: "center",
-    },
-  });
+  const { theme, themePreference, changeTheme } = useContext(ThemeContext);
 
   return (
-    <View style={[styles.container, theme.styles.container]}>
-      <Text style={[styles.huge, theme.styles.text]}>
-        App Appearance Screen
-      </Text>
-      <Text style={[styles.huge, theme.styles.text]}>Theme: {theme.name}</Text>
+    <View style={[theme.styles.screenContainer]}>
+      <StyledText>
+        Customize the app experience by choosing a theme preference:
+      </StyledText>
       <WhiteSpace />
-      <Button type={"primary"} onPress={() => changeTheme("light")}>
-        Set light theme
-      </Button>
-      <Button type={"primary"} onPress={() => changeTheme("dark")}>
-        Set dark theme
-      </Button>
-      <Button type={"primary"} onPress={() => changeTheme("system")}>
-        Set system theme
-      </Button>
+
+      <Radio.Group
+        onChange={(e: any) => changeTheme(e.target.value)}
+        value={themePreference}
+      >
+        <Radio.RadioItem value={"system"} left>
+          <View style={styles.option}>
+            <StyledText>System</StyledText>
+          </View>
+        </Radio.RadioItem>
+        <Radio.RadioItem value={"light"} left>
+          <View style={styles.option}>
+            <StyledText>Light</StyledText>
+          </View>
+        </Radio.RadioItem>
+        <Radio.RadioItem value={"dark"} left>
+          <View style={styles.option}>
+            <StyledText>Dark</StyledText>
+          </View>
+        </Radio.RadioItem>
+      </Radio.Group>
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  option: {
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "center",
+    marginLeft: -4,
+  },
+});

--- a/src/screens/ThemeScreen.tsx
+++ b/src/screens/ThemeScreen.tsx
@@ -5,6 +5,7 @@ import { WhiteSpace, View, Radio } from "@ant-design/react-native";
 
 import { ThemeContext } from "@contexts/theme";
 import { StyledText } from "@components/StyledText";
+import { THEME_NAMES } from "@constants/theme";
 
 export const ThemeScreen = () => {
   const { theme, themePreference, changeTheme } = useContext(ThemeContext);
@@ -20,17 +21,17 @@ export const ThemeScreen = () => {
         onChange={(e: any) => changeTheme(e.target.value)}
         value={themePreference}
       >
-        <Radio.RadioItem style={styles.radio} value={"system"} left>
+        <Radio.RadioItem style={styles.radio} value={THEME_NAMES.system} left>
           <View style={styles.option}>
             <StyledText style={styles.optionText}>System</StyledText>
           </View>
         </Radio.RadioItem>
-        <Radio.RadioItem style={styles.radio} value={"light"} left>
+        <Radio.RadioItem style={styles.radio} value={THEME_NAMES.light} left>
           <View style={styles.option}>
             <StyledText style={styles.optionText}>Light</StyledText>
           </View>
         </Radio.RadioItem>
-        <Radio.RadioItem style={styles.radio} value={"dark"} left>
+        <Radio.RadioItem style={styles.radio} value={THEME_NAMES.dark} left>
           <View style={styles.option}>
             <StyledText style={styles.optionText}>Dark</StyledText>
           </View>

--- a/src/screens/__tests__/ThemeScreen.test.tsx
+++ b/src/screens/__tests__/ThemeScreen.test.tsx
@@ -1,12 +1,28 @@
-import { render, screen } from "@testing-library/react-native";
+import { fireEvent, screen } from "@testing-library/react-native";
+
+import { renderWithTheme } from "@contexts/utils/theme.utils";
 import { ThemeScreen } from "@screens/ThemeScreen";
+import { THEME_NAMES } from "@constants/theme";
+
+import "@testing-library/jest-native/extend-expect";
+
+// Test Utils
+const getInfoText = () =>
+  screen.getByText("Customize the app", {
+    exact: false,
+  });
 
 describe("<ThemeScreen />", () => {
-  // Trivial test that checks if the component renders some text on the screen
-  it("has the text app appearance screen", () => {
-    render(<ThemeScreen />);
+  it("renders with the passed theme", () => {
+    renderWithTheme(<ThemeScreen />, THEME_NAMES.dark);
+    expect(getInfoText()).toHaveStyle({ color: "#ffffff" });
+  });
 
-    const textComponent = screen.getByText("App Appearance Screen");
-    expect(textComponent).toBeTruthy();
+  it("updates the theme on radio button selection", () => {
+    renderWithTheme(<ThemeScreen />, THEME_NAMES.light);
+    expect(getInfoText()).toHaveStyle({ color: "#000000" });
+    // Select the dark radio button
+    fireEvent.press(screen.getByText("Dark"));
+    expect(getInfoText()).toHaveStyle({ color: "#ffffff" });
   });
 });


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Build UI page 4.4 from the mockups to allow users to change their preferred theme.

Part of #15 

This change is a

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

## Preview
![Animation](https://user-images.githubusercontent.com/40010849/210280292-b32d0f06-710c-4f7a-9237-7454207f947f.gif)

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->

- Update the theme with colors for dark and light to work for the page. Cleaned up some constants too.
- Cleaned up the theme test with new constants and refactored the custom render function to also use it for testing the theme screen.
- Update the theme screen to use the Radio buttons from ant-design to switch between system, light and dark.
- Fixed the `StyledText` component to depend on the theme context to properly render text color automatically.
- Add tests to check if the components are re-rendering with the right colors when the user selects a different theme.

Tested manually to ensure it works. This mostly already leverages the theme context previously setup.

There seems to be a visual bug on emulator where some of the lines separating options don't appear as well as others. This doesn't appear on physical devices. But if we decide to remove the lines under each option this might become more involved.

## Motivation/Links
Pretty ui for the theme screen.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
