### PR TITLE
[FEAT] Add modal to confirm delete operation

### DIFF
--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -37,18 +37,10 @@ export const ProfileScreen = ({ navigation }: IProfileScreenProps) => {
       name: "Delete Account",
       onPress: () => {
         Modal.alert(
-          <StyledText
-            style={{
-              fontSize: 18,
-            }}
-          >
+          <StyledText style={styles.deleteModalTitle}>
             Are you sure you want to delete your account?
           </StyledText>,
-          <StyledText
-            style={{
-              textAlign: "center",
-            }}
-          >
+          <StyledText style={styles.deleteModalBody}>
             All data associated with your account will be lost, including any
             reward points.
           </StyledText>,
@@ -189,6 +181,12 @@ const styles = StyleSheet.create({
   },
   navigationText: {
     paddingVertical: 8,
+  },
+  deleteModalTitle: {
+    fontSize: 18,
+  },
+  deleteModalBody: {
+    textAlign: "center",
   },
 });
 

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo, useState } from "react";
+import { useContext, useMemo } from "react";
 import { StyleSheet, ScrollView, Image } from "react-native";
 
 import { View, List, Modal } from "@ant-design/react-native";

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -1,7 +1,7 @@
-import { useContext, useMemo } from "react";
+import { useContext, useMemo, useState } from "react";
 import { StyleSheet, ScrollView, Image } from "react-native";
 
-import { View, List } from "@ant-design/react-native";
+import { View, List, Modal } from "@ant-design/react-native";
 
 import { StyledText } from "@components/StyledText";
 import * as ROUTES from "@constants/routes";
@@ -35,15 +35,45 @@ export const ProfileScreen = ({ navigation }: IProfileScreenProps) => {
     },
     {
       name: "Delete Account",
-      onPress: async () => {
-        try {
-          await signOut();
-          await deleteUser(userProfile!.email);
-        } catch (error) {
-          displayError(
-            `Failed to delete user account. Try again later. ${error}`
-          );
-        }
+      onPress: () => {
+        Modal.alert(
+          <StyledText
+            style={{
+              fontSize: 18,
+            }}
+          >
+            Are you sure you want to delete your account?
+          </StyledText>,
+          <StyledText
+            style={{
+              textAlign: "center",
+            }}
+          >
+            All data associated with your account will be lost, including any
+            reward points.
+          </StyledText>,
+          [
+            {
+              text: "Cancel",
+              style: { color: theme.styles.text.color },
+            },
+            {
+              text: "Yes, delete it",
+              onPress: async () => {
+                try {
+                  await signOut();
+                  await deleteUser(userProfile!.email);
+                } catch (error) {
+                  displayError(
+                    `Failed to delete user account. Try again later. ${error}`
+                  );
+                }
+              },
+              style: { color: "red" },
+            },
+          ],
+          () => true
+        );
       },
       style: {
         color: "red",


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Add a confirmation modal when the user tries to delete their account.

This change is a

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

## Preview
![Animation](https://user-images.githubusercontent.com/40010849/213057284-d49da48e-7c96-46ff-a4b4-84b4e6ad2c3e.gif)


## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->

- Adds a `modal.alert` call to make the popup show up and wrap the content of the account deletion on the on-press of "ok" button.

## Motivation/Links
Something to add based on the discussion in class today. Cleaner user experience.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
