### PR TITLE
[FIX] Change Refresh Indicator's Color

### DIFF
--- a/src/screens/WaitTimeScreen.tsx
+++ b/src/screens/WaitTimeScreen.tsx
@@ -268,7 +268,12 @@ export const WaitTimeScreen = ({ navigation }: IWaitTimeScreenProps) => {
         <View style={styles.stepScrollDivider} />
         <ScrollView
           refreshControl={
-            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={onRefresh}
+              progressBackgroundColor={theme.iconColor}
+              tintColor={theme.iconColor}
+            />
           }
         >
           <List>


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->
Fixes the refresh indicator color based on what color mode

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

## Description

`progressBackgroundColor` is an Android prop and `tintColor` is an iOS prop.

https://user-images.githubusercontent.com/17970535/213952365-ee035c92-9e9d-4170-a8ef-040bab56dde3.mov

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->

## Motivation/Links

Consistency

<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
