### PR TITLE
[FEAT] Add rewards page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ web-build/
 
 # env
 .env
+
+# Firebase debug
+firestore-debug.log
+ui-debug.log

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -92,6 +92,19 @@ export interface GetAllPOI200ResponseInner {
 /**
  * 
  * @export
+ * @interface GetPOI404Response
+ */
+export interface GetPOI404Response {
+    /**
+     * Error description
+     * @type {string}
+     * @memberof GetPOI404Response
+     */
+    'message': string;
+}
+/**
+ * 
+ * @export
  * @interface ListRewardEvents200ResponseInner
  */
 export interface ListRewardEvents200ResponseInner {
@@ -106,7 +119,7 @@ export interface ListRewardEvents200ResponseInner {
      * @type {string}
      * @memberof ListRewardEvents200ResponseInner
      */
-    'source': string;
+    'source': ListRewardEvents200ResponseInnerSourceEnum;
     /**
      * Timestamp of the reward event
      * @type {string}
@@ -114,6 +127,16 @@ export interface ListRewardEvents200ResponseInner {
      */
     'timestamp': string;
 }
+
+export const ListRewardEvents200ResponseInnerSourceEnum = {
+    ReferralBonus: 'referral_bonus',
+    ReferredBonus: 'referred_bonus',
+    WaittimeConfirm: 'waittime_confirm',
+    WaittimeSubmit: 'waittime_submit'
+} as const;
+
+export type ListRewardEvents200ResponseInnerSourceEnum = typeof ListRewardEvents200ResponseInnerSourceEnum[keyof typeof ListRewardEvents200ResponseInnerSourceEnum];
+
 /**
  * 
  * @export
@@ -186,12 +209,6 @@ export interface POISuggestion {
      * @type {string}
      * @memberof POISuggestion
      */
-    'submitted_by'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof POISuggestion
-     */
     'suggestion_name': string;
 }
 /**
@@ -211,7 +228,7 @@ export interface RewardEvent {
      * @type {string}
      * @memberof RewardEvent
      */
-    'source': string;
+    'source': RewardEventSourceEnum;
     /**
      * Timestamp of the reward event
      * @type {string}
@@ -219,19 +236,16 @@ export interface RewardEvent {
      */
     'timestamp': string;
 }
-/**
- * 
- * @export
- * @interface SubmitReferralCode400Response
- */
-export interface SubmitReferralCode400Response {
-    /**
-     * Error description
-     * @type {string}
-     * @memberof SubmitReferralCode400Response
-     */
-    'message': string;
-}
+
+export const RewardEventSourceEnum = {
+    ReferralBonus: 'referral_bonus',
+    ReferredBonus: 'referred_bonus',
+    WaittimeConfirm: 'waittime_confirm',
+    WaittimeSubmit: 'waittime_submit'
+} as const;
+
+export type RewardEventSourceEnum = typeof RewardEventSourceEnum[keyof typeof RewardEventSourceEnum];
+
 /**
  * 
  * @export
@@ -244,12 +258,6 @@ export interface SuggestNewPOIRequest {
      * @memberof SuggestNewPOIRequest
      */
     'notes'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof SuggestNewPOIRequest
-     */
-    'submitted_by'?: string;
     /**
      * 
      * @type {string}
@@ -585,7 +593,7 @@ export const POIApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async suggestNewPOI(suggestNewPOIRequest: SuggestNewPOIRequest, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<GetAllPOI200ResponseInner>>> {
+        async suggestNewPOI(suggestNewPOIRequest: SuggestNewPOIRequest, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.suggestNewPOI(suggestNewPOIRequest, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -625,7 +633,7 @@ export const POIApiFactory = function (configuration?: Configuration, basePath?:
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        suggestNewPOI(suggestNewPOIRequest: SuggestNewPOIRequest, options?: any): AxiosPromise<Array<GetAllPOI200ResponseInner>> {
+        suggestNewPOI(suggestNewPOIRequest: SuggestNewPOIRequest, options?: any): AxiosPromise<void> {
             return localVarFp.suggestNewPOI(suggestNewPOIRequest, options).then((request) => request(axios, basePath));
         },
     };
@@ -664,7 +672,7 @@ export interface POIApiInterface {
      * @throws {RequiredError}
      * @memberof POIApiInterface
      */
-    suggestNewPOI(suggestNewPOIRequest: SuggestNewPOIRequest, options?: AxiosRequestConfig): AxiosPromise<Array<GetAllPOI200ResponseInner>>;
+    suggestNewPOI(suggestNewPOIRequest: SuggestNewPOIRequest, options?: AxiosRequestConfig): AxiosPromise<void>;
 
 }
 
@@ -813,7 +821,7 @@ export const UserApiAxiosParamCreator = function (configuration?: Configuration)
                 baseOptions = configuration.baseOptions;
             }
 
-            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 

--- a/src/contexts/auth.tsx
+++ b/src/contexts/auth.tsx
@@ -141,8 +141,12 @@ export const AuthProvider = ({
               Authorization: `Bearer ${await user.getIdToken()}`,
             },
           });
-        } catch (error) {
-          displayError(`Cannot create new account. Try again later. ${error}`);
+        } catch (error: any) {
+          displayError(
+            `Cannot create new account. Try again later. ${
+              error?.response?.data || error
+            }`
+          );
         }
       }
     });

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -101,7 +101,8 @@ export const TabNavigator = () => (
       name={ROUTES.REWARDS}
       component={RewardsScreen}
       options={{
-        title: "Rewards",
+        title: "Rewards History",
+        tabBarLabel: "Rewards",
         tabBarIcon: ({ color, size }) => renderFeatherIcon("gift", color, size),
       }}
     />

--- a/src/screens/RewardsScreen.tsx
+++ b/src/screens/RewardsScreen.tsx
@@ -1,19 +1,182 @@
-import { Text, View, StyleSheet } from "react-native";
+import { useContext, useState, useEffect } from "react";
+import { StyleSheet, FlatList } from "react-native";
 
-export const RewardsScreen = () => (
-  <View style={styles.container}>
-    <Text style={styles.huge}>Rewards Screen</Text>
-  </View>
-);
+import { AntDesign } from "@expo/vector-icons";
+import { View, List } from "@ant-design/react-native";
+
+import { AuthContext } from "@contexts/auth";
+import { userApi } from "@api/client/apis";
+import { ThemeContext } from "@contexts/theme";
+import { StyledText } from "@components/StyledText";
+import {
+  ListRewardEvents200ResponseInner,
+  ListRewardEvents200ResponseInnerSourceEnum,
+} from "@api/generated";
+import { displayError } from "@utils/error";
+
+/**
+ * Convert from system value of reward source to human readable string
+ * @param source Reward source
+ * @returns Equivalent human readable string
+ */
+const cleanRewardSource = (
+  source: ListRewardEvents200ResponseInnerSourceEnum
+): string => {
+  switch (source) {
+    case ListRewardEvents200ResponseInnerSourceEnum.ReferralBonus:
+      return "Referral Bonus";
+    case ListRewardEvents200ResponseInnerSourceEnum.ReferredBonus:
+      return "Referred Bonus";
+    case ListRewardEvents200ResponseInnerSourceEnum.WaittimeConfirm:
+      return "Wait Time Confirm";
+    case ListRewardEvents200ResponseInnerSourceEnum.WaittimeSubmit:
+      return "Wait Time Submit";
+    default:
+      return "Reward Event";
+  }
+};
+
+const HorizontalRule = () => <View style={styles.hr} />;
+
+export const RewardsScreen = () => {
+  const { theme } = useContext(ThemeContext);
+  const { user, userProfile } = useContext(AuthContext);
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [rewardsEvents, setRewardsEvents] = useState<
+    ListRewardEvents200ResponseInner[]
+  >([]);
+
+  /**
+   * Make an API call to fetch reward events associated with the user
+   * @param before Timestamp to fetch events before, used when the end of the list is reached to append more events
+   * @param limit Limit the number of events returned
+   */
+  const fetchRewardsEvents = async (before?: string, limit?: number) => {
+    try {
+      const res = await userApi.listRewardEvents(before, limit, {
+        headers: { Authorization: `Bearer ${await user!.getIdToken()}` },
+      });
+      if (before) {
+        setRewardsEvents(rewardsEvents.concat(res.data));
+      } else {
+        setRewardsEvents(res.data);
+      }
+    } catch (err: any) {
+      displayError(
+        `Failed to fetch reward events. ${err?.response?.data?.message || err}`
+      );
+    }
+  };
+
+  // Refresh the list of reward events
+  const refresh = async () => {
+    setRefreshing(true);
+    await fetchRewardsEvents();
+    setRefreshing(false);
+  };
+
+  /**
+   * Fetch more reward events when the end of the list is reached
+   */
+  const fetchMoreEvents = async () => {
+    if (rewardsEvents.length > 0) {
+      const lastEvent = rewardsEvents[rewardsEvents.length - 1];
+      await fetchRewardsEvents(lastEvent.timestamp);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return (
+    <View style={[theme.styles.screenContainer, styles.container]}>
+      <FlatList
+        onRefresh={() => refresh()}
+        refreshing={refreshing}
+        onEndReached={() => fetchMoreEvents()}
+        onEndReachedThreshold={0.4}
+        data={rewardsEvents}
+        keyExtractor={(item, index) =>
+          `reward-${index}-${item.points}-source-${item.source}`
+        }
+        ListHeaderComponent={<HorizontalRule />}
+        renderItem={({ item }) => (
+          <List.Item
+            thumb={
+              <View>
+                <AntDesign name="staro" size={22} color={theme.iconColor} />
+              </View>
+            }
+            extra={
+              <View>
+                <List.Item.Brief style={styles.rewardItemBrief}>
+                  <StyledText style={theme.styles.secondaryColor}>
+                    {`+${item.points} points`}
+                  </StyledText>
+                </List.Item.Brief>
+              </View>
+            }
+          >
+            <View style={styles.rewardItem}>
+              <StyledText style={[theme.styles.secondaryColor, styles.date]}>
+                {new Date(item.timestamp).toDateString()}
+              </StyledText>
+              <StyledText style={[theme.styles.text, styles.rewardName]}>
+                {cleanRewardSource(item.source)}
+              </StyledText>
+            </View>
+          </List.Item>
+        )}
+      />
+      <View style={styles.rewardPointsContainer}>
+        <AntDesign
+          name="star"
+          size={24}
+          color={theme.styles.primaryColor.color}
+        />
+        <StyledText
+          style={[theme.styles.primaryText, styles.rewardsPointsText]}
+          fontWeight="bold"
+        >
+          {`${userProfile?.rewardPointBalance || 0} points`}
+        </StyledText>
+      </View>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
-  huge: {
-    fontSize: 20,
-  },
   container: {
-    flex: 1,
-    backgroundColor: "#fff",
+    padding: 0,
+    flexDirection: "column",
+  },
+  date: {
+    fontSize: 14,
+  },
+  rewardName: {
+    fontSize: 16,
+  },
+  rewardItem: {
+    paddingVertical: 8,
+    marginLeft: 12,
+  },
+  rewardItemBrief: {
+    textAlign: "right",
+  },
+  rewardPointsContainer: {
+    paddingVertical: 18,
     alignItems: "center",
     justifyContent: "center",
+    flexDirection: "row",
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  rewardsPointsText: {
+    fontSize: 20,
+    marginLeft: 8,
+  },
+  hr: {
+    borderTopWidth: StyleSheet.hairlineWidth,
   },
 });

--- a/src/screens/RewardsScreen.tsx
+++ b/src/screens/RewardsScreen.tsx
@@ -88,6 +88,7 @@ export const RewardsScreen = () => {
 
   useEffect(() => {
     refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Implements the UI for the rewards history page, so users can see their point total and where those points came from.

Still might add tests later, depending on the time crunch this week.

Closes #58 

This change is a

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

### Preview
![Animation](https://user-images.githubusercontent.com/40010849/219989113-a2b98419-3972-4feb-b722-3fb37c959bf7.gif)

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->
- Regenerated the API
- Relabeled the header for the rewards page to "Rewards History"
- Updated the UI for the rewards page to create an infinite scrolling list.

## Motivation/Links
Implements the UI as shown in the mocks for the rewards page.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
