### PR TITLE
[FIX] Clean up formatting and prevent going back on onboarding

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -22,7 +22,16 @@ module.exports = function (api) {
       [
         "module:react-native-dotenv",
         {
+          envName: "APP_ENV",
+          moduleName: "@env",
+          path: ".env",
+          blocklist: null,
+          allowlist: null,
+          blacklist: null, // DEPRECATED
+          whitelist: null, // DEPRECATED
+          safe: false,
           allowUndefined: false,
+          verbose: false,
         },
       ],
     ],

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,6 +10,7 @@ module.exports = function (api) {
             "@api": "./src/api",
             "@components": "./src/components",
             "@contexts": "./src/contexts",
+            "@hooks": "./src/hooks",
             "@navigators": "./src/navigators",
             "@screens": "./src/screens",
             "@constants": "./src/constants",

--- a/eas.json
+++ b/eas.json
@@ -15,9 +15,15 @@
       }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "extends": "production"
     },
-    "production": {}
+    "production": {
+      "env": {
+        "BASE_URL": "https://queuetime.tech/api",
+        "ENVIRONMENT": "prod"
+      }
+    }
   },
   "submit": {
     "production": {}

--- a/src/hooks/preventBack.tsx
+++ b/src/hooks/preventBack.tsx
@@ -7,5 +7,5 @@ export const usePreventBack = (callback: () => void = () => {}) => {
   useEffect(() => {
     navigation.addListener("beforeRemove", (e: any) => e.preventDefault());
     callback();
-  }, [navigation]);
+  }, [navigation, callback]);
 };

--- a/src/hooks/preventBack.tsx
+++ b/src/hooks/preventBack.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+import { useNavigation } from "@react-navigation/native";
+
+export const usePreventBack = (callback: () => void = () => {}) => {
+  const navigation = useNavigation();
+  useEffect(() => {
+    navigation.addListener("beforeRemove", (e: any) => e.preventDefault());
+    callback();
+  }, [navigation]);
+};

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -18,7 +18,6 @@ import { StyledText } from "@components/StyledText";
 import { AuthContext } from "@contexts/auth";
 import { completeUserOnboarding } from "@utils/firestore";
 import { displayError } from "@utils/error";
-import { OnboardingScreenProps } from "@navigators/SignUpStackNavigator";
 import { usePreventBack } from "@hooks/preventBack";
 
 interface ICarouselItemProps {
@@ -57,11 +56,7 @@ const CAROUSEL_ITEMS: ICarouselItemProps[] = [
  * since it's a pain to pass it through the navigator. Only required for the stack navigator.
  * See https://reactnavigation.org/docs/hello-react-navigation/#passing-additional-props.
  */
-export const OnboardingScreenForNavigator = ({
-  navigation,
-}: {
-  navigation: OnboardingScreenProps["navigation"];
-}) => {
+export const OnboardingScreenForNavigator = () => {
   const { userProfile } = useContext(AuthContext);
 
   // Prevent going back

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -19,6 +19,7 @@ import { AuthContext } from "@contexts/auth";
 import { completeUserOnboarding } from "@utils/firestore";
 import { displayError } from "@utils/error";
 import { OnboardingScreenProps } from "@navigators/SignUpStackNavigator";
+import { usePreventBack } from "@hooks/preventBack";
 
 interface ICarouselItemProps {
   key: string;
@@ -64,11 +65,7 @@ export const OnboardingScreenForNavigator = ({
   const { userProfile } = useContext(AuthContext);
 
   // Prevent going back
-  useEffect(
-    () =>
-      navigation.addListener("beforeRemove", (e: any) => e.preventDefault()),
-    [navigation]
-  );
+  usePreventBack();
 
   const completeOnboarding = async () => {
     try {

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -18,6 +18,7 @@ import { StyledText } from "@components/StyledText";
 import { AuthContext } from "@contexts/auth";
 import { completeUserOnboarding } from "@utils/firestore";
 import { displayError } from "@utils/error";
+import { OnboardingScreenProps } from "@navigators/SignUpStackNavigator";
 
 interface ICarouselItemProps {
   key: string;
@@ -55,8 +56,19 @@ const CAROUSEL_ITEMS: ICarouselItemProps[] = [
  * since it's a pain to pass it through the navigator. Only required for the stack navigator.
  * See https://reactnavigation.org/docs/hello-react-navigation/#passing-additional-props.
  */
-export const OnboardingScreenForNavigator = () => {
+export const OnboardingScreenForNavigator = ({
+  navigation,
+}: {
+  navigation: OnboardingScreenProps["navigation"];
+}) => {
   const { userProfile } = useContext(AuthContext);
+
+  // Prevent going back
+  useEffect(
+    () =>
+      navigation.addListener("beforeRemove", (e: any) => e.preventDefault()),
+    [navigation]
+  );
 
   const completeOnboarding = async () => {
     try {

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -71,7 +71,7 @@ export const ProfileScreen = ({ navigation }: IProfileScreenProps) => {
                   // Fetch token *before* signing out
                   const token = await user!.getIdToken();
                   await signOut();
-                  await userApi.deleteUserProfile({
+                  userApi.deleteUserProfile({
                     headers: {
                       Authorization: `Bearer ${token}`,
                     },

--- a/src/screens/ReferralScreen.tsx
+++ b/src/screens/ReferralScreen.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import { Image, StyleSheet, TouchableOpacity, Dimensions } from "react-native";
 
 import { View, WhiteSpace, InputItem } from "@ant-design/react-native";
@@ -32,6 +32,13 @@ export const ReferralScreen = ({ navigation }: IReferralScreenProps) => {
       width: userInput ? "100%" : "95%",
     },
   });
+
+  // Prevent going back
+  useEffect(
+    () =>
+      navigation.addListener("beforeRemove", (e: any) => e.preventDefault()),
+    [navigation]
+  );
 
   const onSubmit = () => {
     if (isTransitioning) {

--- a/src/screens/ReferralScreen.tsx
+++ b/src/screens/ReferralScreen.tsx
@@ -8,6 +8,7 @@ import { StyledText } from "@components/StyledText";
 import { ThemeContext } from "@contexts/theme";
 import { ReferralScreenProps } from "@navigators/SignUpStackNavigator";
 import { ONBOARDING } from "@constants/routes";
+import { usePreventBack } from "@hooks/preventBack";
 
 const MAX_CHARS = 6;
 const PLACEHOLDER = "XCJDHC";
@@ -34,11 +35,7 @@ export const ReferralScreen = ({ navigation }: IReferralScreenProps) => {
   });
 
   // Prevent going back
-  useEffect(
-    () =>
-      navigation.addListener("beforeRemove", (e: any) => e.preventDefault()),
-    [navigation]
-  );
+  usePreventBack();
 
   const onSubmit = () => {
     if (isTransitioning) {

--- a/src/screens/ReferralScreen.tsx
+++ b/src/screens/ReferralScreen.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useEffect } from "react";
+import { useContext, useState } from "react";
 import { Image, StyleSheet, TouchableOpacity, Dimensions } from "react-native";
 
 import { View, WhiteSpace, InputItem } from "@ant-design/react-native";

--- a/src/screens/TermsOfServiceScreen.tsx
+++ b/src/screens/TermsOfServiceScreen.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect } from "react";
+import { useContext } from "react";
 import { StyleSheet, ScrollView } from "react-native";
 
 import { View, Button } from "@ant-design/react-native";

--- a/src/screens/TermsOfServiceScreen.tsx
+++ b/src/screens/TermsOfServiceScreen.tsx
@@ -7,6 +7,7 @@ import { ThemeContext } from "@contexts/theme";
 import { StyledText } from "@components/StyledText";
 import { REFERRAL } from "@constants/routes";
 import { TermsOfServiceScreenProps } from "@navigators/SignUpStackNavigator";
+import { usePreventBack } from "@hooks/preventBack";
 
 const TERMS_OF_SERVICE = `
 The information you provide will be collected by QueueTime, Inc. for the purpose of collecting, consolidating and sharing live POI wait time throughout the academic school year at McMaster University to provide a service for students to view wait times across campus. This information is collected under sections 20(b), 22(2)(a) & 27(2)(c) & 34(1)(a) of the Freedom of Information and Protection of Privacy Act (FOIP). 
@@ -20,11 +21,7 @@ export const TermsOfServiceScreen = ({
   const { theme } = useContext(ThemeContext);
 
   // Prevent going back
-  useEffect(
-    () =>
-      navigation.addListener("beforeRemove", (e: any) => e.preventDefault()),
-    [navigation]
-  );
+  usePreventBack();
 
   const onAccept = async () => {
     navigation.navigate(REFERRAL);

--- a/src/screens/TermsOfServiceScreen.tsx
+++ b/src/screens/TermsOfServiceScreen.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { StyleSheet, ScrollView } from "react-native";
 
 import { View, Button } from "@ant-design/react-native";
@@ -6,6 +6,7 @@ import { View, Button } from "@ant-design/react-native";
 import { ThemeContext } from "@contexts/theme";
 import { StyledText } from "@components/StyledText";
 import { REFERRAL } from "@constants/routes";
+import { TermsOfServiceScreenProps } from "@navigators/SignUpStackNavigator";
 
 const TERMS_OF_SERVICE = `
 The information you provide will be collected by QueueTime, Inc. for the purpose of collecting, consolidating and sharing live POI wait time throughout the academic school year at McMaster University to provide a service for students to view wait times across campus. This information is collected under sections 20(b), 22(2)(a) & 27(2)(c) & 34(1)(a) of the Freedom of Information and Protection of Privacy Act (FOIP). 
@@ -13,8 +14,17 @@ The information you provide will be collected by QueueTime, Inc. for the purpose
 Non-identifying information will be collected by QueueTime for the purpose of reporting total numbers of registered users. Contact information of individuals will be collected for the purpose of communicating prize details only. Information provided may be used by QueueTime for system management and planning, policy development and analysis of wait times on campus. Contact information will not be used for this purpose; only your random anonymized User ID and other de-identified data will be used. QueueTime enables you to exchange non-identifying information with other users via Bluetooth; other users will not have access to any of your individually identifying information.
 `;
 
-export const TermsOfServiceScreen = ({ navigation }: any) => {
+export const TermsOfServiceScreen = ({
+  navigation,
+}: ITermsOfServiceScreenProps) => {
   const { theme } = useContext(ThemeContext);
+
+  // Prevent going back
+  useEffect(
+    () =>
+      navigation.addListener("beforeRemove", (e: any) => e.preventDefault()),
+    [navigation]
+  );
 
   const onAccept = async () => {
     navigation.navigate(REFERRAL);
@@ -68,3 +78,7 @@ const styles = StyleSheet.create({
     color: "#ffffff",
   },
 });
+
+interface ITermsOfServiceScreenProps {
+  navigation: TermsOfServiceScreenProps["navigation"];
+}

--- a/src/screens/WaitTimeScreen.tsx
+++ b/src/screens/WaitTimeScreen.tsx
@@ -199,9 +199,7 @@ export const WaitTimeScreen = ({ navigation }: IWaitTimeScreenProps) => {
         searchBar?.inputRef?.blur();
       }}
     >
-      <View
-        style={[theme.styles.screenContainer, styles.removeBottonScreenPadding]}
-      >
+      <View style={[theme.styles.screenContainer, styles.container]}>
         <View style={styles.searchContainer}>
           <SearchBar
             ref={(el) => ((searchBar as any) = el)}
@@ -299,6 +297,7 @@ export const WaitTimeScreen = ({ navigation }: IWaitTimeScreenProps) => {
                     {renderIcon(poi.type, theme.iconColor)}
                   </View>
                 }
+                style={styles.poiItem}
               >
                 <StyledText style={styles.poiDistanceText}>
                   {poi.distance + " km"}
@@ -317,17 +316,20 @@ export const WaitTimeScreen = ({ navigation }: IWaitTimeScreenProps) => {
 };
 
 const styles = StyleSheet.create({
-  removeBottonScreenPadding: {
+  container: {
     paddingBottom: 0,
+    paddingHorizontal: 0,
   },
   searchContainer: {
-    paddingTop: Platform.OS === "ios" ? 35 : 0,
+    marginTop: Platform.OS === "ios" ? 35 : 0,
+    paddingHorizontal: 20,
   },
   searchBar: {
     borderRadius: 6,
   },
   sortContainer: {
-    paddingTop: 20,
+    marginTop: 20,
+    paddingHorizontal: 20,
   },
   tags: {
     paddingRight: 6,
@@ -400,6 +402,9 @@ const styles = StyleSheet.create({
     paddingTop: 30,
     borderBottomColor: "#EEEEEE",
     borderBottomWidth: 0.5,
+  },
+  poiItem: {
+    paddingHorizontal: 25,
   },
   poiWaitTimeText: {
     textAlign: "right",

--- a/src/screens/WaitTimeScreen.tsx
+++ b/src/screens/WaitTimeScreen.tsx
@@ -404,7 +404,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 0.5,
   },
   poiItem: {
-    paddingHorizontal: 25,
+    paddingLeft: 25,
   },
   poiWaitTimeText: {
     textAlign: "right",

--- a/src/screens/__tests__/ReferralScreen.test.tsx
+++ b/src/screens/__tests__/ReferralScreen.test.tsx
@@ -13,6 +13,17 @@ import "@testing-library/jest-native/extend-expect";
 const textInputId = "referral-input-textbox";
 const getTextInputBox = () => screen.getByTestId(textInputId);
 
+// Mock useNavigation hook
+jest.mock("@react-navigation/native", () => {
+  const actualNav = jest.requireActual("@react-navigation/native");
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      addListener: jest.fn(),
+    }),
+  };
+});
+
 describe("<ReferralScreen />", () => {
   const mockNavigate = jest.fn();
   const navigation: any = { navigate: mockNavigate };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       "@components/*": ["src/components/*"],
       "@constants/*": ["src/constants/*"],
       "@contexts/*": ["src/contexts/*"],
+      "@hooks/*": ["src/hooks/*"],
       "@navigators/*": ["src/navigators/*"],
       "@screens/*": ["src/screens/*"],
       "@utils/*": ["src/utils/*"]


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Fixes the padding bugs and formatting on the poi list page and adds a hook to prevent going back during onboarding.

Didn't refactor your hook in the poi list item page since it's a little more complex and wanted to keep it simple for now.

Closes #67 and #66 

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->
- Add new hook under /hooks
- Add hook to onboarding pages
- Update styles on poi list page

## Motivation/Links
Clean up styling and make it not possible to go back during onboarding.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
