### PR TITLE
[FIX] Sign-in screen flicker

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -191,6 +191,10 @@ export const OnboardingScreen = ({
         )}
         pagingEnabled
         onViewableItemsChanged={onViewRef.current}
+        viewabilityConfig={{
+          // Tell the flatlist to trigger onViewItemChanged when 50% of the item is visible, otherwise sometimes will not trigger
+          itemVisiblePercentThreshold: 50,
+        }}
         horizontal
         decelerationRate={"normal"}
         scrollEventThrottle={16}

--- a/src/utils/firestore.tsx
+++ b/src/utils/firestore.tsx
@@ -1,3 +1,5 @@
+import { userApi } from "@api/client/apis";
+import { FirebaseAuthTypes } from "@react-native-firebase/auth";
 import firestore, {
   FirebaseFirestoreTypes,
 } from "@react-native-firebase/firestore";
@@ -5,7 +7,6 @@ import firestore, {
 /**
  * Firestore constants
  */
-
 const USER_COLLECTION = "users";
 
 /**
@@ -31,3 +32,57 @@ export const subscribeToUserUpdates = (
     .collection(USER_COLLECTION)
     .doc(userEmail)
     .onSnapshot((doc) => onSnapshot(doc));
+
+/**
+ * Find a user document in firestore
+ * @param userEmail User email of user to find
+ * @returns Firestore document snapshot
+ */
+const findUser = async (userEmail: string) =>
+  firestore().collection(USER_COLLECTION).doc(userEmail).get();
+
+/**
+ * Verify if a user exists in firestore. If not create a new user document with their information
+ * @param user Firebase auth user object
+ * @param userEmail User email
+ * @param onComplete Callback to run on complete. Takes as param the user document from firebase, either newly created or existing
+ * @param onError Callback to run on error
+ */
+export const createUserIfNotExists = async (
+  user: FirebaseAuthTypes.User,
+  userEmail: string,
+  onComplete?: (
+    userDoc: FirebaseFirestoreTypes.DocumentSnapshot<FirebaseFirestoreTypes.DocumentData>
+  ) => void,
+  onError?: (error: any) => void
+) => {
+  try {
+    let userDoc = await findUser(userEmail);
+    if (!userDoc.exists || typeof userDoc.data() === undefined) {
+      await userApi.newUserSignup({
+        headers: {
+          Authorization: `Bearer ${await user.getIdToken()}`,
+        },
+      });
+      userDoc = await findUser(userEmail);
+    }
+    onComplete?.(userDoc);
+  } catch (error: any) {
+    onError?.(error);
+  }
+};
+
+export const firestoreDocToUserProfile = (
+  email: string,
+  data: FirebaseFirestoreTypes.DocumentData
+) => ({
+  email: email,
+  hasCompletedOnboarding: data.hasCompletedOnboarding,
+  hasUsedReferralCode: data.hasUsedReferralCode,
+  notificationSetting: data.notification_setting,
+  numLinesParticipated: data.num_lines_participated,
+  poiFrequency: data.poi_frequency,
+  referralCode: data.referral_code,
+  rewardPointBalance: data.reward_point_balance,
+  timeInLine: data.time_in_line,
+});


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Fixes the issue where once signed-in, if you closed the app then re-opened it, you would briefly see the sign-in page before being redirected to the home screen. This is not a great user experience so this PR fixes it. Also bundles the calls to sign the user in and create a firebase user together so we never have a weird situation where one works and the other doesn't.

Closes #61 

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

## Preview

![Animation](https://user-images.githubusercontent.com/40010849/225175673-67b8ebd2-bf97-40d2-9c5f-4c4beb0dbf74.gif)

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->
 - Refactor the auth context to instead when the user sign-in to Google Identity we also make a call to firebase to get a user snapshot document. If one doesn't exist we create one right there. We then set the state for both simultaneously, add a small timeout then remove the splash screen overlay to reveal the home page. The state variable helping coordinate this is `isFirebaseInitializing`.
 - Fix a minor bug where some elements of the flatlist wouldn't trigger to ref update so the active index would skip them. Found a fix online that sets the visibility threshold to 50% seems to fix it. The weird thing is it works for 1,2,3,5,6 pages but not 4, go figure.
 - Added new firestore utils functions to support extra calls.

## Motivation/Links
Cleans up the sign-in process to be more robust and remove the annoying sign-in screen flicker.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
