### PR TITLE
[FIX] Fix the onboarding wording and remove notifications from profile

### DIFF
--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -58,8 +58,8 @@ const CAROUSEL_ITEMS: ICarouselItemProps[] = [
     content:
       "Allow QTime to access your location to get the most out of the app.\n\n" +
       (Platform.OS === "ios"
-        ? 'Make sure to change the location permissions to "Always Allow" for QTime.\nGo to Settings > Privacy > Location Services > QTime > "Always Allow"'
-        : 'Make sure to enable "Always Allow" for QTime in your location permissions.\nGo to Settings > Apps > QTime > Permissions > Location (Always Allow)'),
+        ? 'Make sure to "Always Allow" the location permissions QTime.\nPress "Allow while using the app" then press "Change to Always Allow"'
+        : 'Make sure to enable "Always Allow" for QTime in your location permissions'),
 
     image: require("@assets/images/OnboardingD.png"),
   },

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -7,6 +7,7 @@ import {
   ImageSourcePropType,
   Image,
   TouchableOpacity,
+  Platform,
 } from "react-native";
 import * as Location from "expo-location";
 
@@ -34,28 +35,32 @@ const CAROUSEL_ITEMS: ICarouselItemProps[] = [
     key: "A",
     title: "Your connection\nis the key.",
     content:
-      "Anonymous identifier keys are constantly exchanged between people using QTime wherever you go.",
+      "For QTime to come up with accurate estimates, anonomized device location GPS data is exchanged with QTime while you're on campus.",
     image: require("@assets/images/OnboardingA.png"),
   },
   {
     key: "B",
     title: "Help out your McMaster\ncommunity.",
     content:
-      "Everyone's time is valuable, so share your estimated wait times for POIs on campus and view times submitted by others.",
+      "Everyone's time is valuable, so you can share your estimates for wait times around campus to help others.",
     image: require("@assets/images/OnboardingB.png"),
   },
   {
     key: "C",
-    title: "Privacy is our number\none priority.",
+    title: "Privacy is our priority.",
     content:
-      "All data is stored locally on your device and your identity is not shared with anyone.\n",
+      "All data is stored securely, with sensitive data anonymized and encrypted on QTime systems. Your data is never sold or shared with third parties.",
     image: require("@assets/images/OnboardingC.png"),
   },
   {
     key: "D",
     title: "Allow location for accurate\nwait times.",
     content:
-      "Allow QTime to access your location to get the most accurate wait times possible.",
+      "Allow QTime to access your location to get the most out of the app.\n\n" +
+      (Platform.OS === "ios"
+        ? 'Make sure to change the location permissions to "Always Allow" for QTime.\nGo to Settings > Privacy > Location Services > QTime > "Always Allow"'
+        : 'Make sure to enable "Always Allow" for QTime in your location permissions.\nGo to Settings > Apps > QTime > Permissions > Location (Always Allow)'),
+
     image: require("@assets/images/OnboardingD.png"),
   },
 ];

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -32,10 +32,11 @@ export const ProfileScreen = ({ navigation }: IProfileScreenProps) => {
 
   // Navigation details for the list of buttons at the bottom of the screen
   const navigationOptions = [
-    {
-      name: "Notification Settings",
-      onPress: () => navigation.navigate(ROUTES.NOTIFICATIONS),
-    },
+    // Hidden for now since not implemented for expo
+    // {
+    //   name: "Notification Settings",
+    //   onPress: () => navigation.navigate(ROUTES.NOTIFICATIONS),
+    // },
     {
       name: "App Appearance",
       onPress: () => navigation.navigate(ROUTES.THEME),

--- a/src/screens/TermsOfServiceScreen.tsx
+++ b/src/screens/TermsOfServiceScreen.tsx
@@ -9,12 +9,6 @@ import { REFERRAL } from "@constants/routes";
 import { TermsOfServiceScreenProps } from "@navigators/SignUpStackNavigator";
 import { usePreventBack } from "@hooks/preventBack";
 
-const TERMS_OF_SERVICE = `
-The information you provide will be collected by QueueTime, Inc. for the purpose of collecting, consolidating and sharing live POI wait time throughout the academic school year at McMaster University to provide a service for students to view wait times across campus. This information is collected under sections 20(b), 22(2)(a) & 27(2)(c) & 34(1)(a) of the Freedom of Information and Protection of Privacy Act (FOIP). 
-
-Non-identifying information will be collected by QueueTime for the purpose of reporting total numbers of registered users. Contact information of individuals will be collected for the purpose of communicating prize details only. Information provided may be used by QueueTime for system management and planning, policy development and analysis of wait times on campus. Contact information will not be used for this purpose; only your random anonymized User ID and other de-identified data will be used. QueueTime enables you to exchange non-identifying information with other users via Bluetooth; other users will not have access to any of your individually identifying information.
-`;
-
 export const TermsOfServiceScreen = ({
   navigation,
 }: ITermsOfServiceScreenProps) => {
@@ -36,6 +30,10 @@ export const TermsOfServiceScreen = ({
         Terms & Conditions
       </StyledText>
       <ScrollView style={styles.terms}>
+        <StyledText fontWeight="bold" style={styles.termsHeader}>
+          TERMS OF SERVICE
+        </StyledText>
+        <StyledText>FOR TESTING PURPOSES ONLY</StyledText>
         <StyledText style={styles.termsText}>{TERMS_OF_SERVICE}</StyledText>
       </ScrollView>
       <Button style={styles.acceptButton} type="primary" onPress={onAccept}>
@@ -65,6 +63,10 @@ const styles = StyleSheet.create({
     marginTop: 22,
     marginBottom: 25,
   },
+  termsHeader: {
+    fontSize: 20,
+    marginTop: 20,
+  },
   termsText: {
     textAlign: "justify",
   },
@@ -79,3 +81,9 @@ const styles = StyleSheet.create({
 interface ITermsOfServiceScreenProps {
   navigation: TermsOfServiceScreenProps["navigation"];
 }
+
+const TERMS_OF_SERVICE = `
+The information you provide will be collected by QueueTime, Inc. for the purpose of collecting, consolidating and sharing live wait time estimates throughout the academic school year at McMaster University to provide a service for students to view wait times across campus. This information is collected under sections 20(b), 22(2)(a) & 27(2)(c) & 34(1)(a) of the Freedom of Information and Protection of Privacy Act (FOIP). 
+
+Non-identifying information will be collected by QueueTime for the purpose of reporting total numbers of registered users. Contact information of individuals will be collected for the purpose of communicating prize details only. Information provided may be used by QueueTime for system management and planning, policy development and analysis of wait times on campus. Contact information will not be used for this purpose; only your random anonymized User ID and other de-identified data will be used. QueueTime enables you to exchange non-identifying information with other users via Bluetooth; other users will not have access to any of your individually identifying information.
+`;


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Updates the wording for the onboarding pages and removes the notification page from the profile page.

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->
- Final polishing touches before submitting to the app store for review.
- Changed the wording of the onboarding screen.

## Motivation/Links
Cleaner and conveys the message we want now.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
