### PR TITLE
[FIX] Bug where `setRecoil` would not be loaded

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -57,7 +57,7 @@ const App = () => {
 
   // Set IS_READY to true to allow the background tracking task to update the geolocation state without breaking
   useEffect(() => {
-    process.env["IS_READY"] = "true";
+    process.env.IS_READY = "true";
   }, []);
 
   if (!fontsLoaded) {

--- a/App.tsx
+++ b/App.tsx
@@ -55,6 +55,11 @@ const App = () => {
     onRootLayoutView();
   }, [onRootLayoutView]);
 
+  // Set IS_READY to true to allow the background tracking task to update the geolocation state without breaking
+  useEffect(() => {
+    process.env["IS_READY"] = "true";
+  }, []);
+
   if (!fontsLoaded) {
     return null;
   }

--- a/src/hooks/backgroundTrackingTask.tsx
+++ b/src/hooks/backgroundTrackingTask.tsx
@@ -2,12 +2,16 @@ import { useEffect } from "react";
 
 import * as Location from "expo-location";
 import * as TaskManager from "expo-task-manager";
+
 import { setRecoil } from "recoil-nexus";
 
 import { displayError } from "@utils/error";
 import { userGeolocationState } from "@atoms/geolocationAtom";
 
 export const LOCATION_TASK_NAME = "LOCATION_BACKGROUND_TRACKING";
+
+// Use is ready var to track when the app is fully rendered
+process.env["IS_READY"] = "false";
 
 // Define the background task for location tracking
 TaskManager.defineTask(
@@ -19,14 +23,14 @@ TaskManager.defineTask(
     }
     if (data) {
       const { latitude, longitude } = data.locations[0].coords;
-      // Delaying the update of the geolocation state to avoid getting setRecoil is not a function error
-      setTimeout(() => {
+      // Use IS_READY to delay the update of the geolocation state to avoid getting setRecoil is not a function error
+      if (process.env.IS_READY === "true") {
         setRecoil(userGeolocationState, {
           latitude,
           longitude,
           timestamp: Date.now(),
         });
-      }, 2000);
+      }
     }
   }
 );

--- a/src/hooks/backgroundTrackingTask.tsx
+++ b/src/hooks/backgroundTrackingTask.tsx
@@ -11,7 +11,7 @@ import { userGeolocationState } from "@atoms/geolocationAtom";
 export const LOCATION_TASK_NAME = "LOCATION_BACKGROUND_TRACKING";
 
 // Use is ready var to track when the app is fully rendered
-process.env["IS_READY"] = "false";
+process.env.IS_READY = "false";
 
 // Define the background task for location tracking
 TaskManager.defineTask(


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Fixes a bug where `setRecoil` would be undefined since it gets loaded when the app context loads. So uses a environment variable to allow it to start using the function. This `IS_READY` var gets to true once the app context is loaded.

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->

## Motivation/Links

<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
