### PR TITLE
[FIX] Allow no location in app

### DIFF
--- a/src/hooks/checkLocationPermission.tsx
+++ b/src/hooks/checkLocationPermission.tsx
@@ -39,8 +39,16 @@ export const requestPermissions = () => {
       {
         text: "Open Settings",
         style: "default",
+        isPreferred: true, // @ts-ignore This is only available on iOS
         onPress: () => Linking.openSettings(),
       },
-    ]
+      {
+        text: "Later",
+        style: "cancel",
+      },
+    ],
+    {
+      cancelable: true,
+    }
   );
 };

--- a/src/hooks/checkLocationPermission.tsx
+++ b/src/hooks/checkLocationPermission.tsx
@@ -39,7 +39,6 @@ export const requestPermissions = () => {
       {
         text: "Open Settings",
         style: "default",
-        isPreferred: true, // @ts-ignore This is only available on iOS
         onPress: () => Linking.openSettings(),
       },
       {

--- a/src/hooks/checkLocationPermission.tsx
+++ b/src/hooks/checkLocationPermission.tsx
@@ -31,7 +31,7 @@ export const useLocationPermission = () => {
   }, []);
 };
 
-export const requestPermissions = () => {
+export const requestPermissions = (onCancel?: () => void) => {
   Alert.alert(
     "Allow Location Access",
     "In order to use this app to its full potential, please allow location access. Set location access to 'Always' for the best experience.",
@@ -44,6 +44,7 @@ export const requestPermissions = () => {
       {
         text: "Later",
         style: "cancel",
+        onPress: () => onCancel?.(),
       },
     ],
     {

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -90,6 +90,8 @@ export const TabNavigator = () => {
   useBackgroundLocation();
 
   useEffect(() => {
+    if (!latitude || !longitude) return;
+
     const callLocationAPI = async () => {
       try {
         sourcingApi.updateUserLocation(

--- a/src/recoil/atoms/geolocationAtom.tsx
+++ b/src/recoil/atoms/geolocationAtom.tsx
@@ -2,7 +2,7 @@ import { atom } from "recoil";
 
 export const userGeolocationState = atom({
   key: "userGeolocationState",
-  default: { latitude: 0, longitude: 0, timestamp: 0 },
+  default: { latitude: null, longitude: null, timestamp: 0 },
 });
 
 export const apiLastCalledTimestampState = atom({

--- a/src/screens/LocationDetailsScreen.tsx
+++ b/src/screens/LocationDetailsScreen.tsx
@@ -96,11 +96,13 @@ export const LocationDetailsScreen = ({
     });
 
   const fetchLocationDetails = async () => {
+    const nonNullLatitude = latitude || 0;
+    const nonNullLongitude = longitude || 0;
     try {
       const res = await poiApi.getPOIDetails(
         route.params.locationId,
-        latitude,
-        longitude,
+        nonNullLatitude,
+        nonNullLongitude,
         {
           headers: { Authorization: `Bearer ${await user!.getIdToken()}` },
         }
@@ -243,7 +245,11 @@ export const LocationDetailsScreen = ({
             {route.params.locationName}
           </StyledText>
           <StyledText style={styles.detailsText}>
-            {`${poiData.address} • ${Math.round(poiData.distance)} m away`}
+            {`${poiData.address} ${
+              latitude && longitude
+                ? " • " + Math.round(poiData.distance) + " m away"
+                : ""
+            }`}
           </StyledText>
         </View>
         <View style={styles.divider} />

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useContext, useState } from "react";
 import { Platform, StyleSheet, View } from "react-native";
-import { useRecoilValue } from "recoil";
 import { useIsFocused } from "@react-navigation/native";
 
 import MapView from "react-native-maps";
@@ -11,7 +10,6 @@ import { GetAllPOI200ResponseInner } from "@api/generated/api";
 import { displayError } from "@utils/error";
 import { AuthContext } from "@contexts/auth";
 import { ThemeContext } from "@contexts/theme";
-import { userGeolocationState } from "@atoms/geolocationAtom";
 import { StyledText } from "@components/StyledText";
 import { WHITE_COLOR, BLACK_COLOR } from "@constants/styles";
 
@@ -21,7 +19,6 @@ export const MapScreen = () => {
   const { user } = useContext(AuthContext);
   const { theme } = useContext(ThemeContext);
   const [poiData, setPoiData] = useState<POI[]>([]);
-  const { latitude, longitude } = useRecoilValue(userGeolocationState);
   const isFocused = useIsFocused();
 
   const styleWithTheme = StyleSheet.create({
@@ -40,15 +37,9 @@ export const MapScreen = () => {
   useEffect(() => {
     const getAllPOIs = async () => {
       try {
-        const res = await poiApi.getAllPOI(
-          latitude,
-          longitude,
-          undefined,
-          undefined,
-          {
-            headers: { Authorization: `Bearer ${await user!.getIdToken()}` },
-          }
-        );
+        const res = await poiApi.getAllPOI(0, 0, undefined, undefined, {
+          headers: { Authorization: `Bearer ${await user!.getIdToken()}` },
+        });
         setPoiData(res.data);
       } catch (err: any) {
         displayError(

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -117,7 +117,7 @@ export const OnboardingScreen = ({
     if (isLastOnboardingPage) {
       await getTrackingPermission();
       if (!backgroundPermission.granted) {
-        requestPermissions();
+        requestPermissions(onComplete);
       } else {
         onComplete?.();
       }

--- a/src/screens/ProfileScreen.tsx
+++ b/src/screens/ProfileScreen.tsx
@@ -148,10 +148,7 @@ export const ProfileScreen = ({ navigation }: IProfileScreenProps) => {
       </View>
       <List>
         <List.Item>
-          <InfoSection
-            text="Most frequented POI"
-            subtext="Location 6 • 0.1 km away"
-          />
+          <InfoSection text="Most frequented POI" subtext="Location 6" />
         </List.Item>
         <List.Item>
           <InfoSection

--- a/src/screens/WaitTimeScreen.tsx
+++ b/src/screens/WaitTimeScreen.tsx
@@ -122,10 +122,13 @@ export const WaitTimeScreen = ({ navigation }: IWaitTimeScreenProps) => {
    * Fetch POIs from the API
    */
   const fetchPOIs = async () => {
+    const nonNullLatitude = latitude || 0;
+    const nonNullLongitude = longitude || 0;
+
     try {
       const res = await poiApi.getAllPOI(
-        latitude,
-        longitude,
+        nonNullLatitude,
+        nonNullLongitude,
         "queue",
         sortBy === SortByEnum.DISTANCE ? "distance" : "estimate",
         {
@@ -371,9 +374,11 @@ export const WaitTimeScreen = ({ navigation }: IWaitTimeScreenProps) => {
                 }
                 style={styles.poiItem}
               >
-                <StyledText style={styles.poiDistanceText}>
-                  {Math.round(poi.distance) + " m"}
-                </StyledText>
+                {latitude && longitude && (
+                  <StyledText style={styles.poiDistanceText}>
+                    {Math.round(poi.distance) + " m"}
+                  </StyledText>
+                )}
                 <StyledText>{poi.name}</StyledText>
                 <StyledText style={styles.poiLastUpdatedText}>
                   {renderLastUpdated(poi.lastUpdated)}


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Allow the app to work even if location is turned off by users. This is to not block the apple store approve process.

Updates the app to either use default values, not show the location distance calculations, or removes the functionality altogether. Allows users to press out of the popup asking them to enable location.

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->
 - Add a new button to opt out of turning on location
 - Add checks and defaults to all api calls requiring location
 - Refactor default location to null instead of 0 to allow for checks if the location has been updated.
 - Refactor code to either not use location (like in map) or only show distance calculations if we have their location.

## Motivation/Links
Allow the apple app store review process to go through.
<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
