### PR TITLE
[FIX] Alert Shouldn’t Pop if User Submits Wait Time

### DIFF
--- a/app.json
+++ b/app.json
@@ -29,9 +29,7 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "usesAppleSignIn": true,
       "supportsTablet": false,
@@ -39,25 +37,18 @@
       "bundleIdentifier": "com.capstone.QTime",
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
-        "UIBackgroundModes": [
-          "location",
-          "fetch"
-        ],
+        "UIBackgroundModes": ["location", "fetch"],
         "CFBundleVersion": "1.0.2",
         "NSLocationUsageDescription": "This app uses your location to locate nearby points of interest and to help us compute accurate wait times and occupancy estimates for points of interest.",
         "NSLocationAlwaysUsageDescription": "This app uses your location in the background to help us compute an accurate wait time for points of interest that you might be waiting in line for.",
         "NSLocationWhenInUseUsageDescription": "This app uses your location to locate nearby points of interest and to help us compute accurate wait times and occupancy estimates for points of interest."
-      },
-      "buildNumber": "2"
+      }
     },
     "android": {
       "googleServicesFile": "./google-services.json",
       "icon": "./assets/android-icon.png",
       "package": "com.capstone.QTime",
-      "permissions": [
-        "ACCESS_BACKGROUND_LOCATION",
-        "ACCESS_FINE_LOCATION"
-      ],
+      "permissions": ["ACCESS_BACKGROUND_LOCATION", "ACCESS_FINE_LOCATION"],
       "config": {
         "googleMaps": {
           "apiKey": "AIzaSyCMNo6cmAGfp4OXo3LpWxSAWK-5Wu7_jys"

--- a/app.json
+++ b/app.json
@@ -29,7 +29,9 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": ["**/*"],
+    "assetBundlePatterns": [
+      "**/*"
+    ],
     "ios": {
       "usesAppleSignIn": true,
       "supportsTablet": false,
@@ -37,18 +39,25 @@
       "bundleIdentifier": "com.capstone.QTime",
       "googleServicesFile": "./GoogleService-Info.plist",
       "infoPlist": {
-        "UIBackgroundModes": ["location", "fetch"],
+        "UIBackgroundModes": [
+          "location",
+          "fetch"
+        ],
         "CFBundleVersion": "1.0.2",
         "NSLocationUsageDescription": "This app uses your location to locate nearby points of interest and to help us compute accurate wait times and occupancy estimates for points of interest.",
         "NSLocationAlwaysUsageDescription": "This app uses your location in the background to help us compute an accurate wait time for points of interest that you might be waiting in line for.",
         "NSLocationWhenInUseUsageDescription": "This app uses your location to locate nearby points of interest and to help us compute accurate wait times and occupancy estimates for points of interest."
-      }
+      },
+      "buildNumber": "2"
     },
     "android": {
       "googleServicesFile": "./google-services.json",
       "icon": "./assets/android-icon.png",
       "package": "com.capstone.QTime",
-      "permissions": ["ACCESS_BACKGROUND_LOCATION", "ACCESS_FINE_LOCATION"],
+      "permissions": [
+        "ACCESS_BACKGROUND_LOCATION",
+        "ACCESS_FINE_LOCATION"
+      ],
       "config": {
         "googleMaps": {
           "apiKey": "AIzaSyCMNo6cmAGfp4OXo3LpWxSAWK-5Wu7_jys"

--- a/src/screens/LocationDetailsScreen.tsx
+++ b/src/screens/LocationDetailsScreen.tsx
@@ -137,6 +137,8 @@ export const LocationDetailsScreen = ({
   const submitNewWaitTime = () => {
     setSubmittedSuccessModal(true);
     sendWaitTimeEstimate(newWaitTime);
+    setWasInteracted(false);
+    setNewWaitTime(0);
     setTimeout(() => {
       setSubmittedSuccessModal(false);
     }, 1500);


### PR DESCRIPTION
## Overview

<!-- Give a brief overview of your changes. -->

Fixes when pop-up that says "Are you sure you want to abandon your estimate?" comes up, it currently pops up even if the user submit their wait time, which is not expected

This change is a

- [x] Bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that will change existing functionality)
- [ ] Documentation update

## Description

<!-- Describe your changes in detail -->
<!-- Enumerate all
 - Areas affected
 - Features added
 - Tests added -->

## Motivation/Links

<!-- Why was this change needed? -->
<!-- Add any relevant links here, issues, cards or other pull requests. -->
